### PR TITLE
fix: flip message bubble hard corner side in RTL layouts

### DIFF
--- a/Android/src/app/src/main/java/com/google/ai/edge/gallery/ui/common/chat/MessageBubbleShape.kt
+++ b/Android/src/app/src/main/java/com/google/ai/edge/gallery/ui/common/chat/MessageBubbleShape.kt
@@ -43,6 +43,7 @@ class MessageBubbleShape(
     density: Density,
   ): Outline {
     val radiusPx = with(density) { radius.toPx() }
+    val hardCornerOnLeft = hardCornerAtLeftOrRight != (layoutDirection == LayoutDirection.Rtl)
     val path =
       Path().apply {
         addRoundRect(
@@ -52,11 +53,11 @@ class MessageBubbleShape(
             right = size.width,
             bottom = size.height,
             topLeftCornerRadius =
-              if (hardCornerAtLeftOrRight) CornerRadius(0f, 0f)
+              if (hardCornerOnLeft) CornerRadius(0f, 0f)
               else CornerRadius(radiusPx, radiusPx),
             topRightCornerRadius =
-              if (hardCornerAtLeftOrRight) CornerRadius(radiusPx, radiusPx)
-              else CornerRadius(0f, 0f), // No rounding here
+              if (hardCornerOnLeft) CornerRadius(radiusPx, radiusPx)
+              else CornerRadius(0f, 0f),
             bottomLeftCornerRadius = CornerRadius(radiusPx, radiusPx),
             bottomRightCornerRadius = CornerRadius(radiusPx, radiusPx),
           )


### PR DESCRIPTION
Updated MessageBubbleShape to dynamically determine the hard corner position based on LayoutDirection.

Closes #367