### PR TITLE
fix: correct FunctionGemma typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ For users without Google Play access, install the apk from the [**latest release
 
 * **Prompt Lab**: A dedicated workspace to test different prompts and single-turn use cases with granular control over model parameters like temperature and top-k.
 
-* **Mobile Actions**: Unlock offline device controls and automated tasks powered entirely by a finetune of FuntionGemma 270m.
+* **Mobile Actions**: Unlock offline device controls and automated tasks powered entirely by a finetune of FunctionGemma 270m.
 
 * **Tiny Garden**: A fun, experimental mini-game that uses natural language to plant and harvest a virtual garden using a finetune of FunctionGemma 270m.
 


### PR DESCRIPTION
## Summary
- fix the README typo from `FuntionGemma` to `FunctionGemma`
- refresh the PR branch with `kuishou68` as the only commit author/committer metadata
