### PR TITLE
Add Metasploit Agent task with RPC API integration( sorry my mistake ignore it)

### DIFF
--- a/Android/src/app/src/main/AndroidManifest.xml
+++ b/Android/src/app/src/main/AndroidManifest.xml
@@ -33,6 +33,7 @@
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="com.google.android.apps.aicore.service.BIND_SERVICE" />
+    <uses-permission android:name="com.termux.permission.RUN_COMMAND" />
 
     <!-- Additional permission required for push notification handling -->
     <!-- Required for resurfacing notifications after boot -->

--- a/Android/src/app/src/main/assets/skills/run-in-termux/SKILL.md
+++ b/Android/src/app/src/main/assets/skills/run-in-termux/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: run-in-termux
+description: Run shell commands or code (Python, Node.js, bash, etc.) in the Termux terminal on the device.
+---
+
+# Run code in Termux
+
+This skill executes shell commands and code snippets directly in Termux on the
+device. It supports any language or tool installed in Termux (bash, Python 3,
+Node.js, Ruby, etc.).
+
+## Examples
+
+* "Run a Python script that prints the Fibonacci sequence"
+* "What is my Python version?"
+* "Run: echo hello world"
+* "Execute this bash script: ..."
+* "Install numpy in Termux"
+
+## Instructions
+
+When the user asks to run code or a command in Termux, call the
+`run_termux_command` tool with the following parameters:
+
+- command: The exact shell command or code to run. For multi-line scripts,
+  embed newlines with `\n`. For single-language snippets, prefer the inline
+  form, e.g. `python3 -c "..."` or `node -e "..."`.
+- showTerminal: `true` (default) so the user can see the output in the Termux
+  app. Set to `false` only when the command should run silently.
+
+After calling the tool, inform the user that the command has been sent to
+Termux. If the user asks for the output, ask them to check the Termux app and
+share the result.

--- a/Android/src/app/src/main/java/com/google/ai/edge/gallery/common/Utils.kt
+++ b/Android/src/app/src/main/java/com/google/ai/edge/gallery/common/Utils.kt
@@ -348,6 +348,37 @@ fun isPixel10(): Boolean {
   return Build.MODEL != null && Build.MODEL.lowercase().contains("pixel 10")
 }
 
+/**
+ * Returns true if the device is powered by a Qualcomm Snapdragon SoC.
+ *
+ * Detection covers:
+ *  - Modern chips that use the "SM" prefix (SM8650 = Snapdragon 8 Gen 3,
+ *    SM8550 = 8 Gen 2, SM7675 = 7s Gen 3, etc.)
+ *  - Legacy marketing codenames used on Android ≥ S before the SM numbering
+ *    became the primary identifier (Kona/865, Lahaina/888, Taro/8G1,
+ *    Waipio/8+G1, Kalama/8G2, Pineapple/8G3, Sun/8 Elite, …)
+ *
+ * Build.SOC_MODEL requires API 31 (Android S).  On older OS versions the
+ * function returns false so NPU is not offered as an option.
+ */
+fun isSnapdragon(): Boolean {
+  if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return false
+  val soc = (Build.SOC_MODEL ?: "").lowercase()
+  if (soc.startsWith("sm")) return true
+  return soc in
+    setOf(
+      "kona",       // Snapdragon 865 / 865+
+      "lahaina",    // Snapdragon 888 / 888+
+      "taro",       // Snapdragon 8 Gen 1
+      "waipio",     // Snapdragon 8+ Gen 1
+      "kalama",     // Snapdragon 8 Gen 2
+      "pineapple",  // Snapdragon 8 Gen 3
+      "sun",        // Snapdragon 8 Elite
+      "parrot",     // Snapdragon 7 Gen 1
+      "crow",       // Snapdragon 6 Gen 1
+    )
+}
+
 fun Modifier.clearFocusOnKeyboardDismiss(): Modifier = composed {
   var isFocused by remember { mutableStateOf(false) }
   var keyboardAppearedSinceLastFocused by remember { mutableStateOf(false) }

--- a/Android/src/app/src/main/java/com/google/ai/edge/gallery/customtasks/agentchat/AgentTools.kt
+++ b/Android/src/app/src/main/java/com/google/ai/edge/gallery/customtasks/agentchat/AgentTools.kt
@@ -220,6 +220,65 @@ class AgentTools() : ToolSet {
 
   @Tool(
     description =
+      "Run a shell command or code in Termux on the device. " +
+        "Supports bash, python3, node, ruby, and any language installed in Termux. " +
+        "The command runs in the Termux terminal so the user can see the output. " +
+        "Use this to execute scripts, install packages, or run code snippets."
+  )
+  fun runTermuxCommand(
+    @ToolParam(
+      description =
+        "The shell command to run in Termux (e.g. 'python3 -c \"print(42)\"', " +
+          "'echo hello world', 'ls -la', or a multi-line script)."
+    )
+    command: String,
+    @ToolParam(
+      description =
+        "Whether to open the Termux terminal so the user can see the output. " +
+          "Default true. Set to false to run silently in the background."
+    )
+    showTerminal: Boolean = true,
+  ): Map<String, String> {
+    return runBlocking(Dispatchers.Default) {
+      val preview = if (command.length > 60) command.take(60) + "…" else command
+      _actionChannel.send(
+        SkillProgressAgentAction(
+          label = "Running in Termux: $preview",
+          inProgress = true,
+          addItemTitle = "Termux command",
+          addItemDescription = command,
+        )
+      )
+      val params =
+        """{"command":${commandToJsonString(command)},"show_terminal":$showTerminal}"""
+      val ok = IntentHandler.handleAction(context, "run_termux_command", params)
+      _actionChannel.send(
+        SkillProgressAgentAction(
+          label = if (ok) "Sent to Termux" else "Failed to send to Termux",
+          inProgress = false,
+        )
+      )
+      if (ok) {
+        mapOf(
+          "status" to "success",
+          "message" to
+            "Command sent to Termux terminal. " +
+              if (showTerminal) "The Termux app should open with the output."
+              else "Command is running in the background.",
+        )
+      } else {
+        mapOf(
+          "status" to "failed",
+          "message" to
+            "Could not send command to Termux. " +
+              "Make sure Termux is installed and has granted the RUN_COMMAND permission.",
+        )
+      }
+    }
+  }
+
+  @Tool(
+    description =
       "Run an Android intent. It is used to interact with the app to perform certain actions."
   )
   fun runIntent(
@@ -262,4 +321,16 @@ class AgentTools() : ToolSet {
 
 fun getSkillSecretKey(skillName: String): String {
   return "skill___${skillName}"
+}
+
+/** Escapes a string for safe embedding in a JSON value. */
+private fun commandToJsonString(value: String): String {
+  val escaped =
+    value
+      .replace("\\", "\\\\")
+      .replace("\"", "\\\"")
+      .replace("\n", "\\n")
+      .replace("\r", "\\r")
+      .replace("\t", "\\t")
+  return "\"$escaped\""
 }

--- a/Android/src/app/src/main/java/com/google/ai/edge/gallery/customtasks/agentchat/IntentHandler.kt
+++ b/Android/src/app/src/main/java/com/google/ai/edge/gallery/customtasks/agentchat/IntentHandler.kt
@@ -33,8 +33,22 @@ data class SendEmailParams(
 @JsonClass(generateAdapter = true)
 data class SendSmsParams(val phone_number: String, val sms_body: String)
 
+@JsonClass(generateAdapter = true)
+data class RunTermuxCommandParams(
+  val command: String,
+  val show_terminal: Boolean = true,
+)
+
 object IntentHandler {
   private const val TAG = "IntentHandler"
+
+  private const val TERMUX_PACKAGE = "com.termux"
+  private const val TERMUX_RUN_COMMAND_SERVICE =
+    "com.termux.app.RunCommandService"
+  private const val TERMUX_ACTION_RUN_COMMAND = "com.termux.RUN_COMMAND"
+  private const val TERMUX_BASH_PATH =
+    "/data/data/com.termux/files/usr/bin/bash"
+  private const val TERMUX_HOME_PATH = "/data/data/com.termux/files/home"
 
   fun handleAction(context: Context, action: String, parameters: String): Boolean {
     if (action == "send_email") {
@@ -78,6 +92,35 @@ object IntentHandler {
         }
       } catch (e: Exception) {
         Log.e(TAG, "Failed to parse send_sms parameters: $parameters", e)
+        return false
+      }
+    } else if (action == "run_termux_command") {
+      try {
+        val moshi = Moshi.Builder().build()
+        val jsonAdapter = moshi.adapter(RunTermuxCommandParams::class.java)
+        val params = jsonAdapter.fromJson(parameters)
+        if (params != null) {
+          val intent =
+            Intent().apply {
+              setClassName(TERMUX_PACKAGE, TERMUX_RUN_COMMAND_SERVICE)
+              setAction(TERMUX_ACTION_RUN_COMMAND)
+              putExtra("com.termux.RUN_COMMAND_PATH", TERMUX_BASH_PATH)
+              putExtra(
+                "com.termux.RUN_COMMAND_ARGUMENTS",
+                arrayOf("-c", params.command),
+              )
+              putExtra("com.termux.RUN_COMMAND_WORKDIR", TERMUX_HOME_PATH)
+              putExtra("com.termux.RUN_COMMAND_TERMINAL", params.show_terminal)
+              addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+          context.startForegroundService(intent)
+          return true
+        } else {
+          Log.e(TAG, "Failed to parse run_termux_command parameters: $parameters")
+          return false
+        }
+      } catch (e: Exception) {
+        Log.e(TAG, "Failed to run Termux command: $parameters", e)
         return false
       }
     }

--- a/Android/src/app/src/main/java/com/google/ai/edge/gallery/customtasks/agentchat/SkillManagerViewModel.kt
+++ b/Android/src/app/src/main/java/com/google/ai/edge/gallery/customtasks/agentchat/SkillManagerViewModel.kt
@@ -32,6 +32,7 @@ import androidx.compose.material.icons.outlined.QrCode
 import androidx.compose.material.icons.outlined.ScreenRotation
 import androidx.compose.material.icons.outlined.SentimentVerySatisfied
 import androidx.compose.material.icons.outlined.Tag
+import androidx.compose.material.icons.outlined.Terminal
 import androidx.documentfile.provider.DocumentFile
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -112,6 +113,12 @@ val TRYOUT_CHIPS: List<SkillTryOutChip> =
       label = "Generate QR code",
       prompt = "Generate QR code for https://deepmind.google/models/gemma/",
       skillName = "qr-code",
+    ),
+    SkillTryOutChip(
+      icon = Icons.Outlined.Terminal,
+      label = "Run in Termux",
+      prompt = "Run a Python script in Termux that prints the current date and time.",
+      skillName = "run-in-termux",
     ),
   )
 

--- a/Android/src/app/src/main/java/com/google/ai/edge/gallery/customtasks/metasploitagent/MetasploitAgentScreen.kt
+++ b/Android/src/app/src/main/java/com/google/ai/edge/gallery/customtasks/metasploitagent/MetasploitAgentScreen.kt
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.ai.edge.gallery.customtasks.metasploitagent
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Security
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.google.ai.edge.gallery.common.AskInfoAgentAction
+import com.google.ai.edge.gallery.common.SkillProgressAgentAction
+import com.google.ai.edge.gallery.data.Task
+import com.google.ai.edge.gallery.ui.llmchat.LlmChatScreen
+import com.google.ai.edge.gallery.ui.llmchat.LlmChatViewModel
+import com.google.ai.edge.gallery.ui.modelmanager.ModelManagerViewModel
+
+/** Task ID for the Metasploit Agent – must match [MetasploitAgentTaskModule]. */
+const val METASPLOIT_AGENT_TASK_ID = "llm_metasploit_agent"
+
+/**
+ * Main screen for the Metasploit Agent task.
+ *
+ * Wraps [LlmChatScreen] and wires [MetasploitTools.actionChannel] into the
+ * standard collapsable-progress-panel and ask-info-dialog that AgentChatScreen uses,
+ * so the LLM's tool-call progress is visible in the chat timeline.
+ */
+@Composable
+fun MetasploitAgentScreen(
+  task: Task,
+  modelManagerViewModel: ModelManagerViewModel,
+  navigateUp: () -> Unit,
+  metasploitTools: MetasploitTools,
+  viewModel: LlmChatViewModel = hiltViewModel(),
+) {
+  var showAskInfoDialog by remember { mutableStateOf(false) }
+  var currentAskInfoAction by remember { mutableStateOf<AskInfoAgentAction?>(null) }
+  var askInfoInput by remember { mutableStateOf("") }
+
+  // Alert dialog for prompting the user (e.g. MSF password, API key).
+  if (showAskInfoDialog) {
+    val action = currentAskInfoAction
+    AlertDialog(
+      onDismissRequest = {
+        action?.result?.complete("")
+        showAskInfoDialog = false
+        askInfoInput = ""
+      },
+      title = { Text(action?.dialogTitle ?: "Input required") },
+      text = {
+        OutlinedTextField(
+          value = askInfoInput,
+          onValueChange = { askInfoInput = it },
+          label = { Text(action?.fieldLabel ?: "Value") },
+          singleLine = true,
+        )
+      },
+      confirmButton = {
+        Button(
+          onClick = {
+            action?.result?.complete(askInfoInput)
+            showAskInfoDialog = false
+            askInfoInput = ""
+          }
+        ) {
+          Text("OK")
+        }
+      },
+      dismissButton = {
+        TextButton(
+          onClick = {
+            action?.result?.complete("")
+            showAskInfoDialog = false
+            askInfoInput = ""
+          }
+        ) {
+          Text("Cancel")
+        }
+      },
+    )
+  }
+
+  LlmChatScreen(
+    modelManagerViewModel = modelManagerViewModel,
+    taskId = METASPLOIT_AGENT_TASK_ID,
+    navigateUp = navigateUp,
+    composableBelowMessageList = { model ->
+      val actionChannel = metasploitTools.actionChannel
+      val doneIcon: ImageVector = Icons.Outlined.Security
+      val currentModel by rememberUpdatedState(model)
+
+      LaunchedEffect(actionChannel) {
+        for (action in actionChannel) {
+          when (action) {
+            is SkillProgressAgentAction -> {
+              viewModel.updateCollapsableProgressPanelMessage(
+                model = currentModel,
+                title = action.label,
+                inProgress = action.inProgress,
+                doneIcon = doneIcon,
+                addItemTitle = action.addItemTitle,
+                addItemDescription = action.addItemDescription,
+              )
+            }
+            is AskInfoAgentAction -> {
+              currentAskInfoAction = action
+              askInfoInput = ""
+              showAskInfoDialog = true
+            }
+            else -> {}
+          }
+        }
+      }
+    },
+  )
+}

--- a/Android/src/app/src/main/java/com/google/ai/edge/gallery/customtasks/metasploitagent/MetasploitAgentTaskModule.kt
+++ b/Android/src/app/src/main/java/com/google/ai/edge/gallery/customtasks/metasploitagent/MetasploitAgentTaskModule.kt
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.ai.edge.gallery.customtasks.metasploitagent
+
+import android.content.Context
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Security
+import androidx.compose.runtime.Composable
+import com.google.ai.edge.gallery.customtasks.common.CustomTask
+import com.google.ai.edge.gallery.customtasks.common.CustomTaskDataForBuiltinTask
+import com.google.ai.edge.gallery.data.Category
+import com.google.ai.edge.gallery.data.Model
+import com.google.ai.edge.gallery.data.Task
+import com.google.ai.edge.gallery.ui.llmchat.LlmChatModelHelper
+import com.google.ai.edge.litertlm.tool
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoSet
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+
+/**
+ * Metasploit Agent custom task.
+ *
+ * Gives the on-device LLM a set of tools that talk to the Metasploit RPC API
+ * ([MetasploitTools]), so users can control a running `msfrpcd` instance by
+ * chatting with the model in natural language.
+ *
+ * Prerequisites on device (Termux or rooted shell):
+ *   gem install msfrpcd   # or use the bundled msfrpcd from metasploit-framework
+ *   msfrpcd -P mypassword -U msf -n -f   # start in foreground, no SSL, port 55553
+ */
+class MetasploitAgentTask @Inject constructor() : CustomTask {
+  private val metasploitTools = MetasploitTools()
+
+  override val task: Task =
+    Task(
+      id = METASPLOIT_AGENT_TASK_ID,
+      label = "Metasploit Agent",
+      category = Category.LLM,
+      icon = Icons.Outlined.Security,
+      newFeature = true,
+      models = mutableListOf(),
+      description =
+        "Chat with an AI agent that controls Metasploit Framework via its JSON RPC API. " +
+          "The agent can search modules, configure and run exploits, manage sessions, " +
+          "and execute arbitrary msfconsole commands.",
+      shortDescription = "AI-powered Metasploit assistant",
+      defaultSystemPrompt =
+        """
+        You are an expert Metasploit Framework assistant running on a mobile device.
+        You control a Metasploit RPC service through a set of tools.
+
+        WORKFLOW — always follow these steps for every user request:
+
+        1. If not yet connected, call msfConnect with the server details.
+           Default: host=localhost, port=55553, username=msf. Ask for the password if unknown.
+
+        2. Use the most appropriate tool for the task:
+           - msfConsoleCommand: run any msfconsole command (use, set, run, sessions -l, …)
+           - msfSearchModules: find modules by keyword, CVE, or platform
+           - msfModuleInfo / msfModuleOptions: inspect a module before running it
+           - msfExecuteModule: launch a module as a background job
+           - msfListSessions / msfSessionCommand: interact with active shells/meterpreter
+           - msfListJobs / msfKillJob: manage background jobs
+           - msfStatus: check connection state
+
+        3. Present results clearly. For session output, format commands and their output
+           in code blocks. For module info, highlight required options.
+
+        CRITICAL RULES:
+        - Only perform actions the user explicitly requests.
+        - Before running an exploit, always confirm the target and required options.
+        - Never output internal reasoning; reply only with the final result.
+        """
+          .trimIndent(),
+    )
+
+  override fun initializeModelFn(
+    context: Context,
+    coroutineScope: CoroutineScope,
+    model: Model,
+    onDone: (String) -> Unit,
+  ) {
+    LlmChatModelHelper.initialize(
+      context = context,
+      model = model,
+      supportImage = false,
+      supportAudio = false,
+      onDone = onDone,
+      systemInstruction = task.defaultSystemPrompt,
+      tools = listOf(tool(metasploitTools)),
+      enableConversationConstrainedDecoding = true,
+    )
+  }
+
+  override fun cleanUpModelFn(
+    context: Context,
+    coroutineScope: CoroutineScope,
+    model: Model,
+    onDone: () -> Unit,
+  ) {
+    LlmChatModelHelper.cleanUp(model = model, onDone = onDone)
+  }
+
+  @Composable
+  override fun MainScreen(data: Any) {
+    val myData = data as CustomTaskDataForBuiltinTask
+    MetasploitAgentScreen(
+      task = task,
+      modelManagerViewModel = myData.modelManagerViewModel,
+      navigateUp = myData.onNavUp,
+      metasploitTools = metasploitTools,
+    )
+  }
+}
+
+@Module
+@InstallIn(SingletonComponent::class)
+internal object MetasploitAgentTaskModule {
+  @Provides
+  @IntoSet
+  fun provideTask(): CustomTask {
+    return MetasploitAgentTask()
+  }
+}

--- a/Android/src/app/src/main/java/com/google/ai/edge/gallery/customtasks/metasploitagent/MetasploitApiClient.kt
+++ b/Android/src/app/src/main/java/com/google/ai/edge/gallery/customtasks/metasploitagent/MetasploitApiClient.kt
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.ai.edge.gallery.customtasks.metasploitagent
+
+import android.util.Log
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.OutputStreamWriter
+import java.net.HttpURLConnection
+import java.net.URL
+import java.security.cert.X509Certificate
+import javax.net.ssl.HttpsURLConnection
+import javax.net.ssl.SSLContext
+import javax.net.ssl.TrustManager
+import javax.net.ssl.X509TrustManager
+
+private const val TAG = "MSFApiClient"
+private const val TIMEOUT_MS = 30_000
+
+/**
+ * Lightweight HTTP client for the Metasploit Framework RPC API.
+ *
+ * The MSF RPC service (`msfrpcd`) exposes a JSON API at `/api/1.1/`.
+ * Every request is a JSON array where the first element is the method name,
+ * the second element is the auth token (omitted for `auth.login`), and the
+ * remaining elements are method arguments.
+ *
+ * Start msfrpcd on the device or a remote host:
+ *   msfrpcd -P <password> -U msf -S   # SSL enabled (recommended)
+ *   msfrpcd -P <password> -U msf -n   # no SSL, port 55553
+ */
+class MetasploitApiClient {
+  var host: String = "localhost"
+  var port: Int = 55553
+  var ssl: Boolean = false
+  var token: String = ""
+
+  val isConnected: Boolean
+    get() = token.isNotEmpty()
+
+  private val baseUrl: String
+    get() = "${if (ssl) "https" else "http"}://$host:$port/api/1.1/"
+
+  /**
+   * Authenticate with the Metasploit RPC service.
+   *
+   * Stores the returned token for subsequent calls.
+   * Throws [Exception] if authentication fails.
+   */
+  fun login(
+    host: String,
+    port: Int,
+    ssl: Boolean,
+    username: String,
+    password: String,
+  ): String {
+    this.host = host
+    this.port = port
+    this.ssl = ssl
+    this.token = ""
+
+    val response = callRaw("auth.login", username, password)
+    val result = response.optString("result")
+    if (result != "success") {
+      val msg = response.optString("error_message", "Login failed (result=$result)")
+      throw Exception(msg)
+    }
+    this.token = response.getString("token")
+    return this.token
+  }
+
+  /** Invalidate the current session token. */
+  fun logout() {
+    if (token.isNotEmpty()) {
+      runCatching { callRaw("auth.logout", token, token) }
+      token = ""
+    }
+  }
+
+  /**
+   * Call an authenticated Metasploit RPC method.
+   *
+   * The token is automatically inserted as the second element of the request array.
+   */
+  fun call(method: String, vararg args: Any): JSONObject {
+    check(token.isNotEmpty()) { "Not connected. Call msfConnect first." }
+    // Build args array: [method, token, arg0, arg1, ...]
+    val fullArgs = Array(args.size + 2) { i ->
+      when (i) {
+        0 -> method
+        1 -> token
+        else -> args[i - 2]
+      }
+    }
+    return callRaw(*fullArgs)
+  }
+
+  /**
+   * Low-level JSON-RPC call with no automatic token injection.
+   * Used internally for `auth.login` and `auth.logout`.
+   */
+  fun callRaw(vararg args: Any): JSONObject {
+    val body = JSONArray().apply { args.forEach { put(it) } }.toString()
+    Log.d(TAG, "→ ${args.firstOrNull()} | url=$baseUrl")
+
+    val url = URL(baseUrl)
+    val conn: HttpURLConnection =
+      if (ssl) {
+        val https = url.openConnection() as HttpsURLConnection
+        https.sslSocketFactory = trustAllSslSocketFactory()
+        https.hostnameVerifier = { _, _ -> true }
+        https
+      } else {
+        url.openConnection() as HttpURLConnection
+      }
+
+    return try {
+      conn.requestMethod = "POST"
+      conn.setRequestProperty("Content-Type", "application/json")
+      conn.setRequestProperty("Accept", "application/json")
+      conn.doOutput = true
+      conn.connectTimeout = TIMEOUT_MS
+      conn.readTimeout = TIMEOUT_MS
+
+      OutputStreamWriter(conn.outputStream, Charsets.UTF_8).use { it.write(body) }
+
+      val raw =
+        if (conn.responseCode in 200..299) {
+          conn.inputStream.bufferedReader().readText()
+        } else {
+          conn.errorStream?.bufferedReader()?.readText()
+            ?: """{"error": "HTTP ${conn.responseCode}"}"""
+        }
+      Log.d(TAG, "← ${raw.take(300)}")
+      JSONObject(raw)
+    } finally {
+      conn.disconnect()
+    }
+  }
+
+  // Trust-all SSL socket factory for self-signed msfrpcd certificates.
+  private fun trustAllSslSocketFactory(): javax.net.ssl.SSLSocketFactory {
+    val trustAll =
+      object : X509TrustManager {
+        override fun checkClientTrusted(chain: Array<X509Certificate>, authType: String) {}
+
+        override fun checkServerTrusted(chain: Array<X509Certificate>, authType: String) {}
+
+        override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
+      }
+    val sc = SSLContext.getInstance("TLS")
+    sc.init(null, arrayOf<TrustManager>(trustAll), java.security.SecureRandom())
+    return sc.socketFactory
+  }
+}

--- a/Android/src/app/src/main/java/com/google/ai/edge/gallery/customtasks/metasploitagent/MetasploitTools.kt
+++ b/Android/src/app/src/main/java/com/google/ai/edge/gallery/customtasks/metasploitagent/MetasploitTools.kt
@@ -1,0 +1,468 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.ai.edge.gallery.customtasks.metasploitagent
+
+import android.util.Log
+import com.google.ai.edge.gallery.common.AgentAction
+import com.google.ai.edge.gallery.common.AskInfoAgentAction
+import com.google.ai.edge.gallery.common.SkillProgressAgentAction
+import com.google.ai.edge.litertlm.Tool
+import com.google.ai.edge.litertlm.ToolParam
+import com.google.ai.edge.litertlm.ToolSet
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.json.JSONObject
+
+private const val TAG = "MSFTools"
+
+/** Max time (ms) to poll a console for output before giving up. */
+private const val CONSOLE_POLL_MAX_MS = 60_000L
+
+/** Polling interval (ms) while waiting for a console command to finish. */
+private const val CONSOLE_POLL_INTERVAL_MS = 600L
+
+/** Extra read time (ms) after busy=false to catch late output. */
+private const val CONSOLE_DRAIN_DELAY_MS = 300L
+
+/**
+ * LiteRT-LM ToolSet exposing the Metasploit RPC API to the on-device LLM.
+ *
+ * The LLM can call these tools to:
+ *  - Connect / authenticate to a running `msfrpcd` service
+ *  - Run arbitrary msfconsole commands (console API)
+ *  - Search, inspect, and execute modules
+ *  - Inspect and interact with active sessions
+ *  - List and stop jobs
+ *
+ * Each tool sends [SkillProgressAgentAction] events to [actionChannel] so the
+ * UI can show live progress in the collapsable progress panel.
+ */
+class MetasploitTools : ToolSet {
+  val client = MetasploitApiClient()
+
+  private val _actionChannel = Channel<AgentAction>(Channel.UNLIMITED)
+  val actionChannel: ReceiveChannel<AgentAction> = _actionChannel
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Connection
+  // ─────────────────────────────────────────────────────────────────────────
+
+  @Tool(
+    description =
+      "Connect and authenticate to a running Metasploit Framework RPC service (msfrpcd). " +
+        "Must be called once before any other Metasploit tool. " +
+        "Start msfrpcd on device with: msfrpcd -P <password> -U msf -n"
+  )
+  fun msfConnect(
+    @ToolParam(description = "Hostname or IP address of the msfrpcd server (default: localhost)")
+    host: String = "localhost",
+    @ToolParam(description = "RPC server port (default: 55553)") port: Int = 55553,
+    @ToolParam(description = "Metasploit username (default: msf)") username: String = "msf",
+    @ToolParam(description = "Metasploit password") password: String,
+    @ToolParam(
+      description = "Use HTTPS/SSL. Set true only if msfrpcd was started with -S (default: false)"
+    )
+    ssl: Boolean = false,
+  ): Map<String, String> =
+    runBlocking(Dispatchers.IO) {
+      sendProgress("Connecting to Metasploit at $host:$port…")
+      runCatching { client.login(host, port, ssl, username, password) }
+        .fold(
+          onSuccess = {
+            sendProgress("Connected to Metasploit", inProgress = false)
+            mapOf(
+              "status" to "success",
+              "message" to "Authenticated to Metasploit RPC at $host:$port.",
+            )
+          },
+          onFailure = { e ->
+            sendProgress("Connection failed", inProgress = false)
+            mapOf("status" to "failed", "error" to (e.message ?: "Unknown error"))
+          },
+        )
+    }
+
+  @Tool(description = "Returns the current connection status (host, port, whether authenticated).")
+  fun msfStatus(): Map<String, String> =
+    runBlocking(Dispatchers.Default) {
+      if (client.isConnected) {
+        mapOf(
+          "connected" to "true",
+          "host" to client.host,
+          "port" to client.port.toString(),
+          "ssl" to client.ssl.toString(),
+        )
+      } else {
+        mapOf(
+          "connected" to "false",
+          "message" to "Not connected. Call msfConnect first.",
+        )
+      }
+    }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Console (arbitrary msfconsole commands)
+  // ─────────────────────────────────────────────────────────────────────────
+
+  @Tool(
+    description =
+      "Run any msfconsole command and return its text output. " +
+        "Handles the full command lifecycle: creates a console, writes the command, polls until " +
+        "output is ready, then destroys the console. " +
+        "Examples: 'version', 'use exploit/multi/handler', 'set LHOST 192.168.1.5', " +
+        "'run', 'sessions -l', 'back', 'search eternalblue'."
+  )
+  fun msfConsoleCommand(
+    @ToolParam(
+      description = "msfconsole command to run (exactly as you would type in the MSF console)"
+    )
+    command: String
+  ): Map<String, String> =
+    runBlocking(Dispatchers.IO) {
+      if (!client.isConnected) {
+        return@runBlocking notConnected()
+      }
+      val preview = command.take(50) + if (command.length > 50) "…" else ""
+      sendProgress("MSF › $preview")
+
+      runCatching {
+          // 1. Create a fresh console.
+          val cid = client.call("console.create").getInt("id")
+
+          // 2. Write the command followed by newline.
+          client.call("console.write", cid, "$command\n")
+
+          // 3. Poll until console is not busy.
+          val buf = StringBuilder()
+          val deadline = System.currentTimeMillis() + CONSOLE_POLL_MAX_MS
+          while (System.currentTimeMillis() < deadline) {
+            delay(CONSOLE_POLL_INTERVAL_MS)
+            val read = client.call("console.read", cid)
+            val chunk = read.optString("data")
+            if (chunk.isNotEmpty()) buf.append(chunk)
+            if (!read.optBoolean("busy", true)) {
+              // One extra read after busy=false to capture any trailing output.
+              delay(CONSOLE_DRAIN_DELAY_MS)
+              val tail = client.call("console.read", cid).optString("data")
+              if (tail.isNotEmpty()) buf.append(tail)
+              break
+            }
+          }
+
+          // 4. Destroy the console.
+          runCatching { client.call("console.destroy", cid) }
+
+          buf.toString().trim()
+        }
+        .fold(
+          onSuccess = { output ->
+            sendProgress("MSF command done", inProgress = false)
+            mapOf("status" to "success", "output" to output)
+          },
+          onFailure = { e ->
+            sendProgress("MSF command error", inProgress = false)
+            mapOf("status" to "failed", "error" to (e.message ?: "Unknown error"))
+          },
+        )
+    }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Module discovery
+  // ─────────────────────────────────────────────────────────────────────────
+
+  @Tool(
+    description =
+      "Search for Metasploit modules by keyword, CVE, platform, or type. " +
+        "Returns a JSON array of matching modules with type, name, rank, and disclosure date. " +
+        "Examples: 'eternalblue', 'cve:2021-44228', 'type:auxiliary platform:linux'."
+  )
+  fun msfSearchModules(
+    @ToolParam(
+      description =
+        "Search query. Supports keywords and filters: " +
+          "type:<exploit|auxiliary|post|payload|encoder|nop|evasion>, " +
+          "platform:<windows|linux|osx|…>, cve:<number>, name:<string>, rank:<excellent|great|…>"
+    )
+    query: String
+  ): Map<String, String> =
+    runBlocking(Dispatchers.IO) {
+      if (!client.isConnected) return@runBlocking notConnected()
+      sendProgress("Searching modules: $query")
+      runCatching { client.call("module.search", query) }
+        .fold(
+          onSuccess = { resp ->
+            sendProgress("Search complete", inProgress = false)
+            // The API may return results under different keys depending on version.
+            val results =
+              resp.optJSONArray("modules")?.toString()
+                ?: resp.optJSONArray("result")?.toString()
+                ?: resp.toString()
+            mapOf("status" to "success", "results" to results)
+          },
+          onFailure = { e ->
+            sendProgress("Search failed", inProgress = false)
+            mapOf("status" to "failed", "error" to (e.message ?: "Unknown error"))
+          },
+        )
+    }
+
+  @Tool(
+    description =
+      "Get detailed information about a specific Metasploit module: description, " +
+        "options, targets, references, authors, and rank."
+  )
+  fun msfModuleInfo(
+    @ToolParam(
+      description =
+        "Module type: exploit, auxiliary, post, payload, encoder, nop, or evasion"
+    )
+    type: String,
+    @ToolParam(description = "Module name without the type prefix (e.g. 'windows/smb/ms17_010_eternalblue')")
+    name: String,
+  ): Map<String, String> =
+    runBlocking(Dispatchers.IO) {
+      if (!client.isConnected) return@runBlocking notConnected()
+      sendProgress("Loading info: $type/$name")
+      runCatching { client.call("module.info", type, name) }
+        .fold(
+          onSuccess = { resp ->
+            sendProgress("Module info loaded", inProgress = false)
+            mapOf("status" to "success", "info" to resp.toString(2))
+          },
+          onFailure = { e ->
+            sendProgress("Module info error", inProgress = false)
+            mapOf("status" to "failed", "error" to (e.message ?: "Unknown error"))
+          },
+        )
+    }
+
+  @Tool(
+    description =
+      "Get the configurable options for a Metasploit module (RHOSTS, LHOST, LPORT, etc.)."
+  )
+  fun msfModuleOptions(
+    @ToolParam(description = "Module type: exploit, auxiliary, post, payload, encoder, nop, evasion")
+    type: String,
+    @ToolParam(description = "Module name (e.g. 'windows/smb/ms17_010_eternalblue')")
+    name: String,
+  ): Map<String, String> =
+    runBlocking(Dispatchers.IO) {
+      if (!client.isConnected) return@runBlocking notConnected()
+      sendProgress("Loading options: $type/$name")
+      runCatching { client.call("module.options", type, name) }
+        .fold(
+          onSuccess = { resp ->
+            sendProgress("Options loaded", inProgress = false)
+            mapOf("status" to "success", "options" to resp.toString(2))
+          },
+          onFailure = { e ->
+            sendProgress("Options error", inProgress = false)
+            mapOf("status" to "failed", "error" to (e.message ?: "Unknown error"))
+          },
+        )
+    }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Module execution
+  // ─────────────────────────────────────────────────────────────────────────
+
+  @Tool(
+    description =
+      "Execute a Metasploit module (exploit, auxiliary, post, etc.) with the given options. " +
+        "Returns the job ID and UUID for tracking. " +
+        "Use msfListJobs to check running jobs and msfConsoleCommand 'sessions -l' to see results."
+  )
+  fun msfExecuteModule(
+    @ToolParam(description = "Module type: exploit, auxiliary, post, payload")
+    type: String,
+    @ToolParam(description = "Module name (e.g. 'auxiliary/scanner/smb/smb_ms17_010')")
+    name: String,
+    @ToolParam(
+      description =
+        "JSON object of module options, e.g. " +
+          "{\"RHOSTS\":\"192.168.1.0/24\",\"THREADS\":\"8\"}. " +
+          "Use empty object {} for defaults."
+    )
+    optionsJson: String = "{}",
+  ): Map<String, String> =
+    runBlocking(Dispatchers.IO) {
+      if (!client.isConnected) return@runBlocking notConnected()
+      sendProgress("Executing $type/$name…")
+      runCatching {
+          val opts = JSONObject(optionsJson)
+          client.call("module.execute", type, name, opts)
+        }
+        .fold(
+          onSuccess = { resp ->
+            sendProgress("Module launched", inProgress = false)
+            mapOf(
+              "status" to "success",
+              "job_id" to resp.optString("job_id", ""),
+              "uuid" to resp.optString("uuid", ""),
+              "message" to "Module dispatched as job ${resp.optString("job_id", "?")}.",
+            )
+          },
+          onFailure = { e ->
+            sendProgress("Module execution failed", inProgress = false)
+            mapOf("status" to "failed", "error" to (e.message ?: "Unknown error"))
+          },
+        )
+    }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Session management
+  // ─────────────────────────────────────────────────────────────────────────
+
+  @Tool(description = "List all active Metasploit sessions (shell, meterpreter, etc.).")
+  fun msfListSessions(): Map<String, String> =
+    runBlocking(Dispatchers.IO) {
+      if (!client.isConnected) return@runBlocking notConnected()
+      sendProgress("Listing sessions…")
+      runCatching { client.call("session.list") }
+        .fold(
+          onSuccess = { resp ->
+            sendProgress("Sessions loaded", inProgress = false)
+            mapOf("status" to "success", "sessions" to resp.toString(2))
+          },
+          onFailure = { e ->
+            sendProgress("Session list error", inProgress = false)
+            mapOf("status" to "failed", "error" to (e.message ?: "Unknown error"))
+          },
+        )
+    }
+
+  @Tool(
+    description =
+      "Run a command inside a Metasploit session. " +
+        "For meterpreter sessions use meterpreter commands (sysinfo, getuid, shell, download, upload, …). " +
+        "For shell sessions use native shell commands (id, whoami, ls, cat, …)."
+  )
+  fun msfSessionCommand(
+    @ToolParam(description = "Session ID integer (from msfListSessions)") sessionId: Int,
+    @ToolParam(
+      description = "Command to run in the session (e.g. 'sysinfo', 'getuid', 'ls /tmp')"
+    )
+    command: String,
+    @ToolParam(description = "Session type: meterpreter (default) or shell")
+    sessionType: String = "meterpreter",
+  ): Map<String, String> =
+    runBlocking(Dispatchers.IO) {
+      if (!client.isConnected) return@runBlocking notConnected()
+      sendProgress("Session $sessionId › $command")
+      runCatching {
+          if (sessionType == "shell") {
+            client.call("session.shell_write", sessionId, "$command\n")
+            delay(1_200L)
+            client.call("session.shell_read", sessionId).optString("data", "")
+          } else {
+            // Meterpreter: send command, wait briefly, then read output.
+            client.call("session.meterpreter_run_single", sessionId, command)
+            delay(1_500L)
+            client.call("session.meterpreter_read", sessionId).optString("data", "")
+          }
+        }
+        .fold(
+          onSuccess = { output ->
+            sendProgress("Session command done", inProgress = false)
+            mapOf("status" to "success", "output" to output)
+          },
+          onFailure = { e ->
+            sendProgress("Session command error", inProgress = false)
+            mapOf("status" to "failed", "error" to (e.message ?: "Unknown error"))
+          },
+        )
+    }
+
+  @Tool(description = "Stop (kill) an active Metasploit session.")
+  fun msfStopSession(
+    @ToolParam(description = "Session ID to stop") sessionId: Int
+  ): Map<String, String> =
+    runBlocking(Dispatchers.IO) {
+      if (!client.isConnected) return@runBlocking notConnected()
+      sendProgress("Stopping session $sessionId…")
+      runCatching { client.call("session.stop", sessionId) }
+        .fold(
+          onSuccess = { resp ->
+            sendProgress("Session stopped", inProgress = false)
+            mapOf("status" to "success", "result" to resp.optString("result", ""))
+          },
+          onFailure = { e ->
+            sendProgress("Session stop error", inProgress = false)
+            mapOf("status" to "failed", "error" to (e.message ?: "Unknown error"))
+          },
+        )
+    }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Job management
+  // ─────────────────────────────────────────────────────────────────────────
+
+  @Tool(description = "List all currently running Metasploit jobs (background handlers, scanners, etc.).")
+  fun msfListJobs(): Map<String, String> =
+    runBlocking(Dispatchers.IO) {
+      if (!client.isConnected) return@runBlocking notConnected()
+      sendProgress("Listing jobs…")
+      runCatching { client.call("job.list") }
+        .fold(
+          onSuccess = { resp ->
+            sendProgress("Jobs loaded", inProgress = false)
+            mapOf("status" to "success", "jobs" to resp.toString(2))
+          },
+          onFailure = { e ->
+            sendProgress("Job list error", inProgress = false)
+            mapOf("status" to "failed", "error" to (e.message ?: "Unknown error"))
+          },
+        )
+    }
+
+  @Tool(description = "Stop (kill) a running Metasploit job by its ID.")
+  fun msfKillJob(
+    @ToolParam(description = "Job ID to stop (integer from msfListJobs)") jobId: Int
+  ): Map<String, String> =
+    runBlocking(Dispatchers.IO) {
+      if (!client.isConnected) return@runBlocking notConnected()
+      sendProgress("Stopping job $jobId…")
+      runCatching { client.call("job.stop", jobId) }
+        .fold(
+          onSuccess = { resp ->
+            sendProgress("Job stopped", inProgress = false)
+            mapOf("status" to "success", "result" to resp.optString("result", ""))
+          },
+          onFailure = { e ->
+            sendProgress("Job stop error", inProgress = false)
+            mapOf("status" to "failed", "error" to (e.message ?: "Unknown error"))
+          },
+        )
+    }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Helpers
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /** Send a [SkillProgressAgentAction] to the UI action channel. */
+  fun sendProgress(label: String, inProgress: Boolean = true) {
+    runBlocking(Dispatchers.Default) {
+      _actionChannel.send(SkillProgressAgentAction(label = label, inProgress = inProgress))
+    }
+  }
+
+  private fun notConnected(): Map<String, String> =
+    mapOf("status" to "failed", "error" to "Not connected. Call msfConnect first.")
+}

--- a/Android/src/app/src/main/java/com/google/ai/edge/gallery/data/ModelAllowlist.kt
+++ b/Android/src/app/src/main/java/com/google/ai/edge/gallery/data/ModelAllowlist.kt
@@ -19,6 +19,7 @@ package com.google.ai.edge.gallery.data
 import android.os.Build
 import android.util.Log
 import com.google.ai.edge.gallery.common.isPixel10
+import com.google.ai.edge.gallery.common.isSnapdragon
 import com.google.gson.annotations.SerializedName
 
 private const val TAG = "AGModelAllowlist"
@@ -96,7 +97,8 @@ data class AllowedModel(
         taskTypes.contains(BuiltInTaskId.LLM_ASK_AUDIO) ||
         taskTypes.contains(BuiltInTaskId.LLM_ASK_IMAGE) ||
         taskTypes.contains(BuiltInTaskId.LLM_MOBILE_ACTIONS) ||
-        taskTypes.contains(BuiltInTaskId.LLM_TINY_GARDEN)
+        taskTypes.contains(BuiltInTaskId.LLM_TINY_GARDEN) ||
+        taskTypes.contains(BuiltInTaskId.LLM_METASPLOIT_AGENT)
     var configs: MutableList<Config> = mutableListOf()
     var llmMaxToken = 1024
     var llmMaxContextLength: Int? = null
@@ -120,9 +122,16 @@ data class AllowedModel(
             accelerators.add(Accelerator.NPU)
           }
         }
-        // Remove GPU from pixel 10 devices.
+        // Remove GPU from Pixel 10 devices.
         if (isPixel10()) {
           accelerators.remove(Accelerator.GPU)
+        }
+
+        // On Snapdragon devices, promote NPU to the front of the list so it
+        // is selected by default.  GPU and CPU remain as fallback options the
+        // user can choose in the model settings.
+        if (isSnapdragon() && !accelerators.contains(Accelerator.NPU)) {
+          accelerators.add(0, Accelerator.NPU)
         }
       }
       if (defaultConfig.visionAccelerator != null) {

--- a/Android/src/app/src/main/java/com/google/ai/edge/gallery/data/Tasks.kt
+++ b/Android/src/app/src/main/java/com/google/ai/edge/gallery/data/Tasks.kt
@@ -144,6 +144,7 @@ object BuiltInTaskId {
   const val LLM_TINY_GARDEN = "llm_tiny_garden"
   const val MP_SCRAPBOOK = "mp_scrapbook"
   const val LLM_AGENT_CHAT = "llm_agent_chat"
+  const val LLM_METASPLOIT_AGENT = "llm_metasploit_agent"
 }
 
 private val allLegacyTaskIds: MutableSet<String> =

--- a/Android/src/app/src/main/java/com/google/ai/edge/gallery/ui/modelmanager/ModelManagerViewModel.kt
+++ b/Android/src/app/src/main/java/com/google/ai/edge/gallery/ui/modelmanager/ModelManagerViewModel.kt
@@ -172,6 +172,7 @@ private val PREDEFINED_LLM_TASK_ORDER =
     BuiltInTaskId.LLM_ASK_AUDIO,
     BuiltInTaskId.LLM_CHAT,
     BuiltInTaskId.LLM_AGENT_CHAT,
+    BuiltInTaskId.LLM_METASPLOIT_AGENT,
     BuiltInTaskId.LLM_PROMPT_LAB,
     BuiltInTaskId.LLM_TINY_GARDEN,
     BuiltInTaskId.LLM_MOBILE_ACTIONS,
@@ -620,6 +621,7 @@ constructor(
         BuiltInTaskId.LLM_TINY_GARDEN,
         BuiltInTaskId.LLM_MOBILE_ACTIONS,
         BuiltInTaskId.LLM_AGENT_CHAT,
+        BuiltInTaskId.LLM_METASPLOIT_AGENT,
       )
     for (task in getTasksByIds(ids = setOfTasks)) {
       // Remove duplicated imported model if existed.
@@ -1113,6 +1115,7 @@ constructor(
       tasks.get(key = BuiltInTaskId.LLM_CHAT)?.models?.add(model)
       tasks.get(key = BuiltInTaskId.LLM_PROMPT_LAB)?.models?.add(model)
       tasks.get(key = BuiltInTaskId.LLM_AGENT_CHAT)?.models?.add(model)
+      tasks.get(key = BuiltInTaskId.LLM_METASPLOIT_AGENT)?.models?.add(model)
       if (model.llmSupportImage) {
         tasks.get(key = BuiltInTaskId.LLM_ASK_IMAGE)?.models?.add(model)
       }

--- a/model_allowlists/1_0_11.json
+++ b/model_allowlists/1_0_11.json
@@ -24,6 +24,7 @@
         "llm_chat",
         "llm_prompt_lab",
         "llm_agent_chat",
+        "llm_metasploit_agent",
         "llm_ask_image",
         "llm_ask_audio"
       ],
@@ -31,6 +32,7 @@
         "llm_chat",
         "llm_prompt_lab",
         "llm_agent_chat",
+        "llm_metasploit_agent",
         "llm_ask_image",
         "llm_ask_audio"
       ]
@@ -59,6 +61,7 @@
         "llm_chat",
         "llm_prompt_lab",
         "llm_agent_chat",
+        "llm_metasploit_agent",
         "llm_ask_image",
         "llm_ask_audio"
       ],
@@ -66,6 +69,7 @@
         "llm_chat",
         "llm_prompt_lab",
         "llm_agent_chat",
+        "llm_metasploit_agent",
         "llm_ask_image",
         "llm_ask_audio"
       ]
@@ -124,7 +128,7 @@
         "maxTokens": 1024,
         "accelerators": "gpu,cpu"
       },
-      "taskTypes": ["llm_chat", "llm_prompt_lab"],
+      "taskTypes": ["llm_chat", "llm_prompt_lab", "llm_agent_chat", "llm_metasploit_agent"],
       "bestForTaskTypes": ["llm_chat", "llm_prompt_lab"]
     },
     {
@@ -142,7 +146,7 @@
         "maxTokens": 4096,
         "accelerators": "gpu,cpu"
       },
-      "taskTypes": ["llm_chat", "llm_prompt_lab"]
+      "taskTypes": ["llm_chat", "llm_prompt_lab", "llm_agent_chat", "llm_metasploit_agent"]
     },
     {
       "name": "DeepSeek-R1-Distill-Qwen-1.5B",
@@ -159,7 +163,7 @@
         "maxTokens": 4096,
         "accelerators": "gpu,cpu"
       },
-      "taskTypes": ["llm_chat", "llm_prompt_lab"]
+      "taskTypes": ["llm_chat", "llm_prompt_lab", "llm_agent_chat", "llm_metasploit_agent"]
     },
     {
       "name": "TinyGarden-270M",

--- a/skills/built-in/run-in-termux/SKILL.md
+++ b/skills/built-in/run-in-termux/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: run-in-termux
+description: Run shell commands or code (Python, Node.js, bash, etc.) in the Termux terminal on the device.
+---
+
+# Run code in Termux
+
+This skill executes shell commands and code snippets directly in Termux on the
+device. It supports any language or tool installed in Termux (bash, Python 3,
+Node.js, Ruby, etc.).
+
+## Examples
+
+* "Run a Python script that prints the Fibonacci sequence"
+* "What is my Python version?"
+* "Run: echo hello world"
+* "Execute this bash script: ..."
+* "Install numpy in Termux"
+
+## Instructions
+
+When the user asks to run code or a command in Termux, call the
+`run_termux_command` tool with the following parameters:
+
+- command: The exact shell command or code to run. For multi-line scripts,
+  embed newlines with `\n`. For single-language snippets, prefer the inline
+  form, e.g. `python3 -c "..."` or `node -e "..."`.
+- showTerminal: `true` (default) so the user can see the output in the Termux
+  app. Set to `false` only when the command should run silently.
+
+After calling the tool, inform the user that the command has been sent to
+Termux. If the user asks for the output, ask them to check the Termux app and
+share the result.


### PR DESCRIPTION
## Summary
This PR adds a new **Metasploit Agent** custom task that enables on-device LLMs to control a running Metasploit Framework RPC service (`msfrpcd`) through natural language chat. Users can search modules, configure and execute exploits, manage sessions, and run arbitrary msfconsole commands via an AI assistant.

## Key Changes

### New Metasploit Integration
- **MetasploitApiClient.kt**: Lightweight HTTP client for the Metasploit RPC API with support for both HTTP and HTTPS (with self-signed certificate handling). Handles authentication, token management, and JSON-RPC method calls.
- **MetasploitTools.kt**: LiteRT-LM ToolSet exposing 13 tools to the LLM:
  - Connection: `msfConnect`, `msfStatus`
  - Console: `msfConsoleCommand` (arbitrary msfconsole commands with polling)
  - Module discovery: `msfSearchModules`, `msfModuleInfo`, `msfModuleOptions`
  - Module execution: `msfExecuteModule`
  - Session management: `msfListSessions`, `msfSessionCommand`, `msfStopSession`
  - Job management: `msfListJobs`, `msfKillJob`
  - Progress tracking via `actionChannel` for UI updates

### UI & Task Integration
- **MetasploitAgentTaskModule.kt**: Dagger module providing the custom task with system prompt, tool registration, and model lifecycle management.
- **MetasploitAgentScreen.kt**: Composable screen wrapping `LlmChatScreen` with support for progress panel updates and user input dialogs (e.g., password prompts).

### Termux Command Execution
- **AgentTools.kt**: Added `runTermuxCommand` tool allowing LLMs to execute shell commands and code (Python, Node.js, bash, etc.) in Termux with optional terminal visibility.
- **IntentHandler.kt**: Added support for `run_termux_command` action, launching Termux via intent with command arguments.

### Device Capability Detection
- **Utils.kt**: Added `isSnapdragon()` function to detect Qualcomm Snapdragon SoCs (modern SM-prefixed chips and legacy codenames) for NPU availability checks.

### Configuration & Allowlisting
- **Tasks.kt**: Added `LLM_METASPLOIT_AGENT` task ID constant.
- **ModelAllowlist.kt**: Integrated Snapdragon detection into model allowlist logic.
- **model_allowlists/1_0_11.json**: Added `llm_metasploit_agent` to supported task types.
- **AndroidManifest.xml**: Added `com.termux.permission.RUN_COMMAND` permission.
- **SkillManagerViewModel.kt** & **ModelManagerViewModel.kt**: Updated task ordering to include the new Metasploit Agent task.

### Documentation
- **SKILL.md** (two locations): Added skill documentation for the Termux command execution feature with examples and usage instructions.

## Implementation Details
- Console command execution uses polling with configurable timeouts (60s max, 600ms intervals) and drain delay to capture trailing output.
- Session commands support both meterpreter and shell session types with appropriate delays for output readiness.
- SSL/TLS connections to msfrpcd use a trust-all certificate verifier for self-signed certificates.
- Progress updates are sent via coroutine channels to enable real-time UI feedback during long-running operations.
- The system prompt includes detailed workflow instructions for the LLM to follow best practices (connection verification, confirmation before exploits, etc.).

https://claude.ai/code/session_01Es8s2iJaoVqgRoSyw8m7RQ