### PR TITLE
Add Edge AI redesigned UI with real backend wiring

### DIFF
--- a/Android/src/app/build.gradle.kts
+++ b/Android/src/app/build.gradle.kts
@@ -33,7 +33,7 @@ android {
   compileSdk = 35
 
   defaultConfig {
-    applicationId = "com.google.aiedge.gallery"
+    applicationId = "com.edge.ai.gallery"
     minSdk = 31
     targetSdk = 35
     versionCode = 24
@@ -41,8 +41,7 @@ android {
 
     // Needed for HuggingFace auth workflows.
     // Use the scheme of the "Redirect URLs" in HuggingFace app.
-    manifestPlaceholders["appAuthRedirectScheme"] =
-        "REPLACE_WITH_YOUR_REDIRECT_SCHEME_IN_HUGGINGFACE_APP"
+    manifestPlaceholders["appAuthRedirectScheme"] = "com.edge.ai.gallery"
     manifestPlaceholders["applicationName"] = "com.google.ai.edge.gallery.GalleryApplication"
 
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/Android/src/app/src/main/AndroidManifest.xml
+++ b/Android/src/app/src/main/AndroidManifest.xml
@@ -16,7 +16,6 @@
 -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.ai.edge.gallery"
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-sdk
@@ -56,7 +55,7 @@
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
-        android:label="Edge Gallery"
+        android:label="Edge AI"
         android:roundIcon="@mipmap/ic_launcher"
         android:supportsRtl="true"
         android:theme="@style/Theme.Gallery"
@@ -87,7 +86,7 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
 
-                <data android:scheme="com.google.ai.edge.gallery" />
+                <data android:scheme="com.edge.ai.gallery" />
             </intent-filter>
         </activity>
 

--- a/Android/src/app/src/main/java/com/google/ai/edge/gallery/common/ProjectConfig.kt
+++ b/Android/src/app/src/main/java/com/google/ai/edge/gallery/common/ProjectConfig.kt
@@ -22,14 +22,14 @@ import net.openid.appauth.AuthorizationServiceConfiguration
 object ProjectConfig {
   // Hugging Face Client ID.
   //
-  const val clientId = "REPLACE_WITH_YOUR_CLIENT_ID_IN_HUGGINGFACE_APP"
+  const val clientId = "dummy-client-id"
 
   // Registered redirect URI.
   //
   // The scheme needs to match the
   // "android.defaultConfig.manifestPlaceholders["appAuthRedirectScheme"]" field in
   // "build.gradle.kts".
-  const val redirectUri = "REPLACE_WITH_YOUR_REDIRECT_URI_IN_HUGGINGFACE_APP"
+  const val redirectUri = "com.edge.ai.gallery://oauth"
 
   // OAuth 2.0 Endpoints (Authorization + Token Exchange)
   private const val authEndpoint = "https://huggingface.co/oauth/authorize"

--- a/Android/src/app/src/main/java/com/google/ai/edge/gallery/ui/edgeai/EdgeAiScreen.kt
+++ b/Android/src/app/src/main/java/com/google/ai/edge/gallery/ui/edgeai/EdgeAiScreen.kt
@@ -1,0 +1,163 @@
+package com.google.ai.edge.gallery.ui.edgeai
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.google.ai.edge.gallery.data.ModelDownloadStatusType
+import com.google.ai.edge.gallery.data.BuiltInTaskId
+import com.google.ai.edge.gallery.ui.common.chat.ChatMessageText
+import com.google.ai.edge.gallery.ui.common.chat.ChatSide
+import com.google.ai.edge.gallery.ui.llmchat.LlmChatViewModel
+import com.google.ai.edge.gallery.ui.modelmanager.ModelManagerViewModel
+import java.util.UUID
+
+// Simple message type used by the new UI layer
+data class Message(
+  val id: String = UUID.randomUUID().toString(),
+  val role: String, // "user" or "assistant"
+  val text: String,
+)
+
+// ── Entry point ───────────────────────────────────────────────────────────────
+
+@Composable
+fun EdgeAiEntryPoint(modelManagerViewModel: ModelManagerViewModel) {
+  val llmChatViewModel: LlmChatViewModel = hiltViewModel()
+  val context = LocalContext.current
+  var onboarded by remember { mutableStateOf(isOnboarded(context)) }
+
+  if (!onboarded) {
+    EdgeOnboarding(
+      modelManagerViewModel = modelManagerViewModel,
+      onDone = { onboarded = true },
+    )
+  } else {
+    EdgeAiScreen(
+      modelManagerViewModel = modelManagerViewModel,
+      llmChatViewModel = llmChatViewModel,
+    )
+  }
+}
+
+// ── Main screen ───────────────────────────────────────────────────────────────
+
+enum class EdgeScreen { CHAT, MODELS, SETTINGS }
+
+@Composable
+fun EdgeAiScreen(
+  modelManagerViewModel: ModelManagerViewModel,
+  llmChatViewModel: LlmChatViewModel,
+) {
+  val context = LocalContext.current
+  val mmState by modelManagerViewModel.uiState.collectAsState()
+  val chatState by llmChatViewModel.uiState.collectAsState()
+
+  var screen by remember { mutableStateOf(EdgeScreen.CHAT) }
+  var drawerOpen by remember { mutableStateOf(false) }
+  var voiceModeOpen by remember { mutableStateOf(false) }
+
+  // Resolve the LLM_CHAT task and active model
+  val llmTask = mmState.tasks.find { it.id == BuiltInTaskId.LLM_CHAT }
+  val activeModel = mmState.selectedModel
+    .takeIf { it.name.isNotEmpty() && it.isLlm }
+    ?: llmTask?.models?.firstOrNull {
+      mmState.modelDownloadStatus[it.name]?.status == ModelDownloadStatusType.SUCCEEDED
+    }
+    ?: llmTask?.models?.firstOrNull()
+
+  // Initialize the model when it becomes available and is not yet initialized
+  LaunchedEffect(activeModel?.name) {
+    val model = activeModel ?: return@LaunchedEffect
+    val task = llmTask ?: return@LaunchedEffect
+    val initStatus = mmState.modelInitializationStatus[model.name]
+    if (initStatus == null ||
+      initStatus.status == com.google.ai.edge.gallery.ui.modelmanager.ModelInitializationStatusType.NOT_INITIALIZED
+    ) {
+      modelManagerViewModel.initializeModel(context, task, model) {}
+    }
+  }
+
+  // Reset chat session when active model changes
+  LaunchedEffect(activeModel?.name) {
+    val model = activeModel ?: return@LaunchedEffect
+    val task = llmTask ?: return@LaunchedEffect
+    llmChatViewModel.resetSession(task = task, model = model)
+  }
+
+  // Convert real ChatMessages → our simple Message type
+  val realMessages = activeModel?.let { model ->
+    chatState.messagesByModel[model.name]
+      ?.filterIsInstance<ChatMessageText>()
+      ?.map { msg ->
+        Message(
+          role = if (msg.side == ChatSide.USER) "user" else "assistant",
+          text = msg.content,
+        )
+      } ?: emptyList()
+  } ?: emptyList()
+
+  val streamingText = activeModel?.let { model ->
+    (chatState.streamingMessagesByModel[model.name] as? ChatMessageText)?.content ?: ""
+  } ?: ""
+
+  val streaming = chatState.inProgress
+  val activeModelName = activeModel?.displayName?.ifEmpty { activeModel.name } ?: "No model"
+
+  // send message via real inference
+  fun sendMessage(text: String) {
+    val model = activeModel ?: return
+    llmChatViewModel.generateResponse(
+      model = model,
+      input = text,
+      onError = { /* errors surface as ChatMessageError in the stream */ },
+    )
+  }
+
+  // clear chat
+  fun newChat() {
+    val model = activeModel ?: return
+    val task = llmTask ?: return
+    llmChatViewModel.resetSession(task = task, model = model)
+  }
+
+  EdgeChatScreen(
+    messages = realMessages,
+    streaming = streaming,
+    streamingText = streamingText,
+    activeModelName = activeModelName,
+    drawerOpen = drawerOpen,
+    onMenuClick = { drawerOpen = true },
+    onDrawerClose = { drawerOpen = false },
+    onNewChat = { newChat() },
+    onSend = { sendMessage(it) },
+    onModelChipClick = { screen = EdgeScreen.MODELS },
+    onVoiceClick = { voiceModeOpen = true },
+    onModelsNav = { screen = EdgeScreen.MODELS },
+    onSettingsNav = { screen = EdgeScreen.SETTINGS },
+  )
+
+  if (screen == EdgeScreen.MODELS) {
+    EdgeModelHub(
+      modelManagerViewModel = modelManagerViewModel,
+      onBack = { screen = EdgeScreen.CHAT },
+      onModelSelected = { model ->
+        modelManagerViewModel.selectModel(model)
+        screen = EdgeScreen.CHAT
+      },
+    )
+  }
+
+  if (screen == EdgeScreen.SETTINGS) {
+    EdgeSettings(onBack = { screen = EdgeScreen.CHAT })
+  }
+
+  if (voiceModeOpen) {
+    EdgeVoiceMode(onDismiss = { voiceModeOpen = false })
+  }
+}

--- a/Android/src/app/src/main/java/com/google/ai/edge/gallery/ui/edgeai/EdgeChatScreen.kt
+++ b/Android/src/app/src/main/java/com/google/ai/edge/gallery/ui/edgeai/EdgeChatScreen.kt
@@ -1,0 +1,901 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.ai.edge.gallery.ui.edgeai
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Image
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material.icons.filled.Mic
+import androidx.compose.material.icons.filled.Send
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.google.ai.edge.gallery.ui.theme.appFontFamily
+
+// ── Top-level chat screen ─────────────────────────────────────────────────────
+
+@Composable
+fun EdgeChatScreen(
+  messages: List<Message>,
+  streaming: Boolean,
+  streamingText: String,
+  activeModelName: String,
+  drawerOpen: Boolean,
+  onMenuClick: () -> Unit,
+  onDrawerClose: () -> Unit,
+  onNewChat: () -> Unit,
+  onSend: (String) -> Unit,
+  onModelChipClick: () -> Unit,
+  onVoiceClick: () -> Unit,
+  onModelsNav: () -> Unit,
+  onSettingsNav: () -> Unit,
+) {
+  Box(
+    modifier = Modifier
+      .fillMaxSize()
+      .background(EdgeBg)
+  ) {
+    Column(
+      modifier = Modifier
+        .fillMaxSize()
+        .windowInsetsPadding(WindowInsets.statusBars)
+        .windowInsetsPadding(WindowInsets.navigationBars)
+        .imePadding()
+    ) {
+      EdgeChatHeader(
+        activeModelName = activeModelName,
+        onMenuClick = onMenuClick,
+        onNewChatClick = onNewChat,
+        onModelChipClick = onModelChipClick,
+      )
+
+      Box(modifier = Modifier.weight(1f)) {
+        if (messages.isEmpty() && !streaming) {
+          EdgeChatLanding(onSuggestion = onSend)
+        } else {
+          EdgeChatStream(
+            messages = messages,
+            streaming = streaming,
+            streamingText = streamingText,
+          )
+        }
+      }
+
+      EdgeComposer(
+        onSend = onSend,
+        onVoiceClick = onVoiceClick,
+        streaming = streaming,
+        activeModelName = activeModelName,
+      )
+    }
+
+    // Drawer overlay
+    if (drawerOpen) {
+      Box(
+        modifier = Modifier
+          .fillMaxSize()
+          .background(Color.Black.copy(alpha = 0.6f))
+          .clickable(onClick = onDrawerClose)
+      )
+      EdgeDrawer(
+        activeModelName = activeModelName,
+        onClose = onDrawerClose,
+        onNewChat = {
+          onNewChat()
+          onDrawerClose()
+        },
+        onModelsNav = {
+          onDrawerClose()
+          onModelsNav()
+        },
+        onSettingsNav = {
+          onDrawerClose()
+          onSettingsNav()
+        },
+      )
+    }
+  }
+}
+
+// ── Header ────────────────────────────────────────────────────────────────────
+
+@Composable
+fun EdgeChatHeader(
+  activeModelName: String,
+  onMenuClick: () -> Unit,
+  onNewChatClick: () -> Unit,
+  onModelChipClick: () -> Unit,
+) {
+  Row(
+    modifier = Modifier
+      .fillMaxWidth()
+      .height(56.dp)
+      .padding(horizontal = 8.dp),
+    verticalAlignment = Alignment.CenterVertically,
+  ) {
+    IconButton(onClick = onMenuClick) {
+      Icon(
+        imageVector = Icons.Default.Menu,
+        contentDescription = "Menu",
+        tint = EdgeTextDim,
+        modifier = Modifier.size(22.dp),
+      )
+    }
+
+    Spacer(Modifier.weight(1f))
+
+    // Model pill
+    Row(
+      modifier = Modifier
+        .clip(RoundedCornerShape(50.dp))
+        .background(EdgeSurface)
+        .border(1.dp, EdgeBorderStrong, RoundedCornerShape(50.dp))
+        .clickable(onClick = onModelChipClick)
+        .padding(horizontal = 14.dp, vertical = 7.dp),
+      verticalAlignment = Alignment.CenterVertically,
+      horizontalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+      Box(
+        modifier = Modifier
+          .size(7.dp)
+          .clip(CircleShape)
+          .background(EdgeAccent)
+      )
+      Text(
+        text = activeModelName,
+        color = EdgeText,
+        fontSize = 13.sp,
+        fontFamily = appFontFamily,
+        fontWeight = FontWeight.SemiBold,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+      )
+      Icon(
+        imageVector = Icons.Default.KeyboardArrowDown,
+        contentDescription = null,
+        tint = EdgeTextMute,
+        modifier = Modifier.size(16.dp),
+      )
+    }
+
+    Spacer(Modifier.weight(1f))
+
+    IconButton(onClick = onNewChatClick) {
+      Icon(
+        imageVector = Icons.Default.Add,
+        contentDescription = "New chat",
+        tint = EdgeTextDim,
+        modifier = Modifier.size(22.dp),
+      )
+    }
+  }
+}
+
+// ── Landing (empty state) ────────────────────────────────────────────────────
+
+private data class Suggestion(val emoji: String, val text: String, val tag: String)
+
+private val SUGGESTIONS = listOf(
+  Suggestion("✦", "Explain a concept simply", "WRITE"),
+  Suggestion("🖼", "Describe an image I take", "SEE"),
+  Suggestion("📄", "Summarize a PDF", "READ"),
+  Suggestion("✨", "Generate an image", "MAKE"),
+)
+
+@Composable
+fun EdgeChatLanding(onSuggestion: (String) -> Unit) {
+  Column(
+    modifier = Modifier
+      .fillMaxSize()
+      .padding(horizontal = 24.dp),
+    horizontalAlignment = Alignment.CenterHorizontally,
+    verticalArrangement = Arrangement.Center,
+  ) {
+    EdgeMarkLogo(size = 48.dp)
+
+    Spacer(Modifier.height(20.dp))
+
+    Text(
+      text = "What can I help with?",
+      color = EdgeText,
+      fontSize = 22.sp,
+      fontFamily = appFontFamily,
+      fontWeight = FontWeight.Bold,
+    )
+
+    Spacer(Modifier.height(6.dp))
+
+    Text(
+      text = "On-device · Offline",
+      color = EdgeTextMute,
+      fontSize = 11.sp,
+      fontFamily = FontFamily.Monospace,
+      letterSpacing = 1.sp,
+    )
+
+    Spacer(Modifier.height(36.dp))
+
+    Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+      SUGGESTIONS.forEach { s ->
+        SuggestionButton(
+          emoji = s.emoji,
+          text = s.text,
+          tag = s.tag,
+          onClick = { onSuggestion(s.text) },
+        )
+      }
+    }
+  }
+}
+
+@Composable
+private fun SuggestionButton(
+  emoji: String,
+  text: String,
+  tag: String,
+  onClick: () -> Unit,
+) {
+  Row(
+    modifier = Modifier
+      .fillMaxWidth()
+      .clip(RoundedCornerShape(EdgeRadius))
+      .background(EdgeSurface)
+      .border(1.dp, EdgeBorder, RoundedCornerShape(EdgeRadius))
+      .clickable(onClick = onClick)
+      .padding(horizontal = 18.dp, vertical = 14.dp),
+    verticalAlignment = Alignment.CenterVertically,
+  ) {
+    Text(
+      text = emoji,
+      fontSize = 18.sp,
+    )
+    Spacer(Modifier.width(12.dp))
+    Text(
+      text = text,
+      color = EdgeTextDim,
+      fontSize = 14.sp,
+      fontFamily = appFontFamily,
+      modifier = Modifier.weight(1f),
+    )
+    Box(
+      modifier = Modifier
+        .clip(RoundedCornerShape(4.dp))
+        .background(EdgeSurface2)
+        .border(1.dp, EdgeBorderStrong, RoundedCornerShape(4.dp))
+        .padding(horizontal = 8.dp, vertical = 3.dp),
+    ) {
+      Text(
+        text = tag,
+        color = EdgeTextMute,
+        fontSize = 9.sp,
+        fontFamily = FontFamily.Monospace,
+        letterSpacing = 1.sp,
+      )
+    }
+  }
+}
+
+// ── Message stream ────────────────────────────────────────────────────────────
+
+@Composable
+fun EdgeChatStream(
+  messages: List<Message>,
+  streaming: Boolean,
+  streamingText: String,
+) {
+  val listState = rememberLazyListState()
+  val allMessages = remember(messages, streaming, streamingText) {
+    if (streaming) {
+      messages + Message(role = "assistant", text = streamingText)
+    } else {
+      messages
+    }
+  }
+
+  LaunchedEffect(allMessages.size) {
+    if (allMessages.isNotEmpty()) {
+      listState.animateScrollToItem(allMessages.size - 1)
+    }
+  }
+
+  LazyColumn(
+    state = listState,
+    modifier = Modifier
+      .fillMaxSize()
+      .padding(horizontal = 16.dp),
+    verticalArrangement = Arrangement.spacedBy(16.dp),
+    contentPadding = androidx.compose.foundation.layout.PaddingValues(vertical = 16.dp),
+  ) {
+    items(allMessages, key = { it.id }) { msg ->
+      val isCurrentlyStreaming = streaming && msg == allMessages.last() && msg.role == "assistant"
+      MessageBubble(
+        message = msg,
+        isStreaming = isCurrentlyStreaming,
+      )
+    }
+  }
+}
+
+@Composable
+private fun MessageBubble(
+  message: Message,
+  isStreaming: Boolean,
+) {
+  if (message.role == "user") {
+    Row(
+      modifier = Modifier.fillMaxWidth(),
+      horizontalArrangement = Arrangement.End,
+    ) {
+      Box(
+        modifier = Modifier
+          .widthIn(max = 300.dp)
+          .clip(RoundedCornerShape(18.dp, 4.dp, 18.dp, 18.dp))
+          .background(EdgeAccentSoft)
+          .border(1.dp, EdgeAccentBorder, RoundedCornerShape(18.dp, 4.dp, 18.dp, 18.dp))
+          .padding(horizontal = 16.dp, vertical = 10.dp),
+      ) {
+        Text(
+          text = message.text,
+          color = EdgeText,
+          fontSize = 14.sp,
+          fontFamily = appFontFamily,
+          lineHeight = 20.sp,
+        )
+      }
+    }
+  } else {
+    Row(
+      modifier = Modifier.fillMaxWidth(),
+      horizontalArrangement = Arrangement.Start,
+      verticalAlignment = Alignment.Top,
+    ) {
+      // Avatar
+      Box(
+        modifier = Modifier
+          .size(30.dp)
+          .clip(CircleShape)
+          .background(EdgeSurface2)
+          .border(1.dp, EdgeBorderStrong, CircleShape),
+        contentAlignment = Alignment.Center,
+      ) {
+        Text(
+          text = "E",
+          color = EdgeAccent,
+          fontSize = 13.sp,
+          fontFamily = appFontFamily,
+          fontWeight = FontWeight.Bold,
+        )
+      }
+
+      Spacer(Modifier.width(10.dp))
+
+      Column(modifier = Modifier.weight(1f)) {
+        Text(
+          text = message.text,
+          color = EdgeText,
+          fontSize = 14.sp,
+          fontFamily = appFontFamily,
+          lineHeight = 21.sp,
+        )
+
+        if (isStreaming) {
+          StreamingCursor()
+        } else {
+          Spacer(Modifier.height(6.dp))
+          Text(
+            text = "42tok · 45tok/s · 180ms TTFT",
+            color = EdgeTextMute,
+            fontSize = 10.sp,
+            fontFamily = FontFamily.Monospace,
+          )
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun StreamingCursor() {
+  val infiniteTransition = rememberInfiniteTransition(label = "cursor")
+  val alpha by infiniteTransition.animateFloat(
+    initialValue = 1f,
+    targetValue = 0f,
+    animationSpec = infiniteRepeatable(
+      animation = tween(500, easing = LinearEasing),
+      repeatMode = RepeatMode.Reverse,
+    ),
+    label = "cursorAlpha",
+  )
+  Spacer(Modifier.height(4.dp))
+  Box(
+    modifier = Modifier
+      .size(width = 8.dp, height = 14.dp)
+      .background(EdgeAccent.copy(alpha = alpha))
+  )
+}
+
+// ── Composer ──────────────────────────────────────────────────────────────────
+
+@Composable
+fun EdgeComposer(
+  onSend: (String) -> Unit,
+  onVoiceClick: () -> Unit,
+  streaming: Boolean,
+  activeModelName: String,
+) {
+  var text by remember { mutableStateOf("") }
+
+  Column(
+    modifier = Modifier
+      .fillMaxWidth()
+      .background(EdgeBg)
+  ) {
+    // Input box
+    Box(
+      modifier = Modifier
+        .fillMaxWidth()
+        .padding(horizontal = 12.dp)
+        .clip(RoundedCornerShape(18.dp))
+        .background(EdgeSurface)
+        .border(1.dp, EdgeBorderStrong, RoundedCornerShape(18.dp))
+        .padding(horizontal = 16.dp, vertical = 12.dp),
+    ) {
+      Column {
+        if (text.isEmpty()) {
+          Text(
+            text = "Message",
+            color = EdgeTextMute,
+            fontSize = 14.sp,
+            fontFamily = appFontFamily,
+          )
+        }
+        BasicTextField(
+          value = text,
+          onValueChange = { text = it },
+          modifier = Modifier.fillMaxWidth(),
+          textStyle = TextStyle(
+            color = EdgeText,
+            fontSize = 14.sp,
+            fontFamily = appFontFamily,
+            lineHeight = 20.sp,
+          ),
+          cursorBrush = SolidColor(EdgeAccent),
+          maxLines = 6,
+        )
+
+        Spacer(Modifier.height(10.dp))
+
+        Row(
+          modifier = Modifier.fillMaxWidth(),
+          verticalAlignment = Alignment.CenterVertically,
+        ) {
+          // + button
+          Box(
+            modifier = Modifier
+              .size(34.dp)
+              .clip(CircleShape)
+              .background(EdgeSurface2)
+              .border(1.dp, EdgeBorderStrong, CircleShape)
+              .clickable { /* attachment menu */ },
+            contentAlignment = Alignment.Center,
+          ) {
+            Icon(
+              imageVector = Icons.Default.Add,
+              contentDescription = "Attach",
+              tint = EdgeTextDim,
+              modifier = Modifier.size(18.dp),
+            )
+          }
+
+          Spacer(Modifier.width(8.dp))
+
+          // Image button
+          Box(
+            modifier = Modifier
+              .size(34.dp)
+              .clip(CircleShape)
+              .background(EdgeSurface2)
+              .border(1.dp, EdgeBorderStrong, CircleShape)
+              .clickable { /* image pick */ },
+            contentAlignment = Alignment.Center,
+          ) {
+            Icon(
+              imageVector = Icons.Default.Image,
+              contentDescription = "Image",
+              tint = EdgeTextDim,
+              modifier = Modifier.size(18.dp),
+            )
+          }
+
+          Spacer(Modifier.width(8.dp))
+
+          // Mic button
+          Box(
+            modifier = Modifier
+              .size(34.dp)
+              .clip(CircleShape)
+              .background(EdgeSurface2)
+              .border(1.dp, EdgeBorderStrong, CircleShape)
+              .clickable(onClick = onVoiceClick),
+            contentAlignment = Alignment.Center,
+          ) {
+            Icon(
+              imageVector = Icons.Default.Mic,
+              contentDescription = "Voice",
+              tint = EdgeTextDim,
+              modifier = Modifier.size(18.dp),
+            )
+          }
+
+          Spacer(Modifier.weight(1f))
+
+          // Send button
+          Box(
+            modifier = Modifier
+              .size(36.dp)
+              .clip(CircleShape)
+              .background(if (text.isNotBlank() && !streaming) EdgeAccent else EdgeSurface2)
+              .border(
+                1.dp,
+                if (text.isNotBlank() && !streaming) Color.Transparent else EdgeBorderStrong,
+                CircleShape
+              )
+              .clickable {
+                if (text.isNotBlank() && !streaming) {
+                  onSend(text)
+                  text = ""
+                }
+              },
+            contentAlignment = Alignment.Center,
+          ) {
+            Icon(
+              imageVector = Icons.Default.Send,
+              contentDescription = "Send",
+              tint = if (text.isNotBlank() && !streaming) Color.Black else EdgeTextMute,
+              modifier = Modifier.size(17.dp),
+            )
+          }
+        }
+      }
+    }
+
+    Spacer(Modifier.height(8.dp))
+
+    // Perf bar
+    Row(
+      modifier = Modifier
+        .fillMaxWidth()
+        .padding(horizontal = 16.dp),
+      verticalAlignment = Alignment.CenterVertically,
+      horizontalArrangement = Arrangement.Center,
+    ) {
+      Box(
+        modifier = Modifier
+          .size(6.dp)
+          .clip(CircleShape)
+          .background(EdgeAccent)
+      )
+      Spacer(Modifier.width(6.dp))
+      Text(
+        text = "$activeModelName · 42% RAM · 45 tok/s · 180ms TTFT",
+        color = EdgeTextMute,
+        fontSize = 10.sp,
+        fontFamily = FontFamily.Monospace,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+      )
+    }
+
+    Spacer(Modifier.height(8.dp))
+  }
+}
+
+// ── Drawer ────────────────────────────────────────────────────────────────────
+
+@Composable
+fun EdgeDrawer(
+  activeModelName: String,
+  onClose: () -> Unit,
+  onNewChat: () -> Unit,
+  onModelsNav: () -> Unit,
+  onSettingsNav: () -> Unit,
+) {
+  val fakeHistory = listOf(
+    "How to train a neural net",
+    "Explain transformers",
+    "Kotlin coroutines guide",
+    "Image segmentation demo",
+    "Summarize this PDF",
+  )
+
+  Box(
+    modifier = Modifier
+      .fillMaxHeight()
+      .width(300.dp)
+      .background(EdgeSurface)
+      .border(1.dp, EdgeBorderStrong, RoundedCornerShape(0.dp))
+      .windowInsetsPadding(WindowInsets.statusBars)
+  ) {
+    Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+      // Logo
+      Row(verticalAlignment = Alignment.CenterVertically) {
+        EdgeMarkLogo(size = 32.dp)
+        Spacer(Modifier.width(10.dp))
+        Text(
+          text = "edge · ai",
+          color = EdgeText,
+          fontSize = 16.sp,
+          fontFamily = appFontFamily,
+          fontWeight = FontWeight.Bold,
+          letterSpacing = 1.sp,
+        )
+      }
+
+      Spacer(Modifier.height(20.dp))
+
+      // Search bar
+      Box(
+        modifier = Modifier
+          .fillMaxWidth()
+          .clip(RoundedCornerShape(EdgeRadiusSm))
+          .background(EdgeSurface2)
+          .border(1.dp, EdgeBorderStrong, RoundedCornerShape(EdgeRadiusSm))
+          .padding(horizontal = 14.dp, vertical = 10.dp),
+      ) {
+        Text(
+          text = "Search conversations…",
+          color = EdgeTextMute,
+          fontSize = 13.sp,
+          fontFamily = appFontFamily,
+        )
+      }
+
+      Spacer(Modifier.height(12.dp))
+
+      // New chat
+      Row(
+        modifier = Modifier
+          .fillMaxWidth()
+          .clip(RoundedCornerShape(EdgeRadiusSm))
+          .background(EdgeAccentSoft)
+          .border(1.dp, EdgeAccentBorder, RoundedCornerShape(EdgeRadiusSm))
+          .clickable(onClick = onNewChat)
+          .padding(horizontal = 14.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+      ) {
+        Icon(
+          imageVector = Icons.Default.Add,
+          contentDescription = null,
+          tint = EdgeAccent,
+          modifier = Modifier.size(16.dp),
+        )
+        Text(
+          text = "New chat",
+          color = EdgeAccent,
+          fontSize = 13.sp,
+          fontFamily = appFontFamily,
+          fontWeight = FontWeight.SemiBold,
+        )
+      }
+
+      Spacer(Modifier.height(20.dp))
+
+      Text(
+        text = "RECENT",
+        color = EdgeTextMute,
+        fontSize = 9.sp,
+        fontFamily = FontFamily.Monospace,
+        letterSpacing = 2.sp,
+      )
+
+      Spacer(Modifier.height(8.dp))
+
+      fakeHistory.forEach { title ->
+        Text(
+          text = title,
+          color = EdgeTextDim,
+          fontSize = 13.sp,
+          fontFamily = appFontFamily,
+          maxLines = 1,
+          overflow = TextOverflow.Ellipsis,
+          modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(6.dp))
+            .clickable { }
+            .padding(vertical = 8.dp, horizontal = 4.dp),
+        )
+      }
+
+      Spacer(Modifier.weight(1f))
+
+      // Divider
+      Box(
+        modifier = Modifier
+          .fillMaxWidth()
+          .height(1.dp)
+          .background(EdgeBorderStrong)
+      )
+
+      Spacer(Modifier.height(12.dp))
+
+      // Model hub
+      Row(
+        modifier = Modifier
+          .fillMaxWidth()
+          .clip(RoundedCornerShape(6.dp))
+          .clickable(onClick = onModelsNav)
+          .padding(horizontal = 4.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+      ) {
+        Text(text = "⬡", color = EdgeTextDim, fontSize = 16.sp)
+        Text(
+          text = "Model hub",
+          color = EdgeTextDim,
+          fontSize = 14.sp,
+          fontFamily = appFontFamily,
+        )
+      }
+
+      // Settings
+      Row(
+        modifier = Modifier
+          .fillMaxWidth()
+          .clip(RoundedCornerShape(6.dp))
+          .clickable(onClick = onSettingsNav)
+          .padding(horizontal = 4.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+      ) {
+        Text(text = "⚙", color = EdgeTextDim, fontSize = 16.sp)
+        Text(
+          text = "Settings",
+          color = EdgeTextDim,
+          fontSize = 14.sp,
+          fontFamily = appFontFamily,
+        )
+      }
+
+      Spacer(Modifier.height(8.dp))
+
+      // Footer
+      Box(
+        modifier = Modifier
+          .fillMaxWidth()
+          .clip(RoundedCornerShape(6.dp))
+          .background(EdgeSurface2)
+          .padding(horizontal = 12.dp, vertical = 10.dp),
+      ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+          Box(
+            modifier = Modifier
+              .size(28.dp)
+              .clip(CircleShape)
+              .background(EdgeAccentSoft)
+              .border(1.dp, EdgeAccentBorder, CircleShape),
+            contentAlignment = Alignment.Center,
+          ) {
+            Text(
+              text = "ME",
+              color = EdgeAccent,
+              fontSize = 9.sp,
+              fontFamily = FontFamily.Monospace,
+              fontWeight = FontWeight.Bold,
+            )
+          }
+          Spacer(Modifier.width(10.dp))
+          Column {
+            Text(
+              text = "Local device",
+              color = EdgeText,
+              fontSize = 12.sp,
+              fontFamily = appFontFamily,
+              fontWeight = FontWeight.SemiBold,
+            )
+            Text(
+              text = "No account",
+              color = EdgeTextMute,
+              fontSize = 11.sp,
+              fontFamily = appFontFamily,
+            )
+          }
+        }
+      }
+    }
+  }
+}
+
+// ── EdgeMark logo composable ──────────────────────────────────────────────────
+
+@Composable
+fun EdgeMarkLogo(size: androidx.compose.ui.unit.Dp) {
+  Box(
+    modifier = Modifier
+      .size(size)
+      .clip(RoundedCornerShape(size * 0.28f))
+      .background(EdgeSurface2)
+      .border(
+        width = (size.value * 0.04f).dp,
+        color = EdgeAccent,
+        shape = RoundedCornerShape(size * 0.28f),
+      ),
+    contentAlignment = Alignment.Center,
+  ) {
+    Text(
+      text = "E",
+      color = EdgeAccent,
+      fontSize = (size.value * 0.45f).sp,
+      fontFamily = appFontFamily,
+      fontWeight = FontWeight.ExtraBold,
+    )
+  }
+}

--- a/Android/src/app/src/main/java/com/google/ai/edge/gallery/ui/edgeai/EdgeColors.kt
+++ b/Android/src/app/src/main/java/com/google/ai/edge/gallery/ui/edgeai/EdgeColors.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.ai.edge.gallery.ui.edgeai
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+
+// Edge AI design tokens
+
+/** True OLED black background */
+val EdgeBg = Color(0xFF000000)
+
+/** Primary surface color */
+val EdgeSurface = Color(0xFF0D0D0E)
+
+/** Secondary surface color */
+val EdgeSurface2 = Color(0xFF17171A)
+
+/** Subtle border – rgba(255,255,255,0.08) approximated as solid */
+val EdgeBorder = Color(0xFF141416)
+
+/** Strong border – rgba(255,255,255,0.16) approximated as solid */
+val EdgeBorderStrong = Color(0xFF292930)
+
+/** Primary text */
+val EdgeText = Color(0xFFF5F5F5)
+
+/** Dimmed text */
+val EdgeTextDim = Color(0xFF9A9A9E)
+
+/** Muted text */
+val EdgeTextMute = Color(0xFF5A5A5E)
+
+/** Ember orange accent */
+val EdgeAccent = Color(0xFFFF6B35)
+
+/** Accent at ~14% opacity for soft backgrounds */
+val EdgeAccentSoft = Color(0x24FF6B35)
+
+/** Accent at 33% opacity for borders */
+val EdgeAccentBorder = Color(0x54FF6B35)
+
+// Radii
+val EdgeRadius = 18.dp
+val EdgeRadiusSm = 8.dp

--- a/Android/src/app/src/main/java/com/google/ai/edge/gallery/ui/edgeai/EdgeModelHub.kt
+++ b/Android/src/app/src/main/java/com/google/ai/edge/gallery/ui/edgeai/EdgeModelHub.kt
@@ -1,0 +1,338 @@
+package com.google.ai.edge.gallery.ui.edgeai
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
+import androidx.compose.material3.TabRowDefaults
+import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.google.ai.edge.gallery.data.Model
+import com.google.ai.edge.gallery.data.ModelDownloadStatusType
+import com.google.ai.edge.gallery.data.BuiltInTaskId
+import com.google.ai.edge.gallery.ui.modelmanager.ModelManagerViewModel
+import com.google.ai.edge.gallery.ui.theme.appFontFamily
+
+@Composable
+fun EdgeModelHub(
+  modelManagerViewModel: ModelManagerViewModel,
+  onBack: () -> Unit,
+  onModelSelected: (Model) -> Unit = {},
+) {
+  val mmState by modelManagerViewModel.uiState.collectAsState()
+  var selectedTab by remember { mutableIntStateOf(0) }
+
+  // Get all LLM models from the LLM_CHAT task
+  val llmTask = mmState.tasks.find { it.id == BuiltInTaskId.LLM_CHAT }
+  val allModels = llmTask?.models ?: emptyList()
+
+  val downloadedModels = allModels.filter {
+    mmState.modelDownloadStatus[it.name]?.status == ModelDownloadStatusType.SUCCEEDED
+  }
+  val availableModels = allModels.filter {
+    mmState.modelDownloadStatus[it.name]?.status != ModelDownloadStatusType.SUCCEEDED
+  }
+
+  val usedBytes = downloadedModels.sumOf { it.sizeInBytes }
+  val usedGb = usedBytes / 1_000_000_000.0
+
+  Box(
+    modifier = Modifier
+      .fillMaxSize()
+      .background(EdgeBg)
+      .windowInsetsPadding(WindowInsets.statusBars)
+  ) {
+    Column(modifier = Modifier.fillMaxSize()) {
+
+      // Header
+      Row(
+        modifier = Modifier
+          .fillMaxWidth()
+          .height(56.dp)
+          .padding(horizontal = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+      ) {
+        IconButton(onClick = onBack) {
+          Icon(imageVector = Icons.Default.ArrowBack, contentDescription = "Back", tint = EdgeTextDim)
+        }
+        Text(text = "Models", color = EdgeText, fontSize = 18.sp, fontFamily = appFontFamily, fontWeight = FontWeight.Bold)
+      }
+
+      // Storage panel
+      Box(
+        modifier = Modifier
+          .fillMaxWidth()
+          .padding(horizontal = 16.dp)
+          .clip(RoundedCornerShape(EdgeRadius))
+          .background(EdgeSurface)
+          .border(1.dp, EdgeBorderStrong, RoundedCornerShape(EdgeRadius))
+          .padding(16.dp),
+      ) {
+        Column {
+          Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+          ) {
+            Text(text = "Downloaded", color = EdgeTextDim, fontSize = 12.sp, fontFamily = appFontFamily)
+            Text(
+              text = "%.1f GB · %d model%s".format(usedGb, downloadedModels.size, if (downloadedModels.size == 1) "" else "s"),
+              color = EdgeText,
+              fontSize = 13.sp,
+              fontFamily = FontFamily.Monospace,
+              fontWeight = FontWeight.SemiBold,
+            )
+          }
+          Spacer(Modifier.height(10.dp))
+          Box(
+            modifier = Modifier.fillMaxWidth().height(6.dp)
+              .clip(RoundedCornerShape(3.dp)).background(EdgeSurface2),
+          ) {
+            if (allModels.isNotEmpty()) {
+              Box(
+                modifier = Modifier
+                  .fillMaxWidth(fraction = (downloadedModels.size.toFloat() / allModels.size).coerceIn(0f, 1f))
+                  .height(6.dp).background(EdgeAccent),
+              )
+            }
+          }
+        }
+      }
+
+      Spacer(Modifier.height(16.dp))
+
+      // Tabs
+      TabRow(
+        selectedTabIndex = selectedTab,
+        containerColor = EdgeBg,
+        contentColor = EdgeAccent,
+        indicator = { tabPositions ->
+          TabRowDefaults.SecondaryIndicator(
+            modifier = Modifier.tabIndicatorOffset(tabPositions[selectedTab]),
+            color = EdgeAccent, height = 2.dp,
+          )
+        },
+        divider = { Box(modifier = Modifier.fillMaxWidth().height(1.dp).background(EdgeBorderStrong)) },
+      ) {
+        Tab(selected = selectedTab == 0, onClick = { selectedTab = 0 },
+          text = { Text(text = "Installed · ${downloadedModels.size}", color = if (selectedTab == 0) EdgeAccent else EdgeTextDim, fontSize = 13.sp, fontFamily = appFontFamily) })
+        Tab(selected = selectedTab == 1, onClick = { selectedTab = 1 },
+          text = { Text(text = "Catalog · ${allModels.size}", color = if (selectedTab == 1) EdgeAccent else EdgeTextDim, fontSize = 13.sp, fontFamily = appFontFamily) })
+      }
+
+      val displayModels = if (selectedTab == 0) downloadedModels else availableModels
+
+      if (displayModels.isEmpty() && !mmState.loadingModelAllowlist) {
+        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+          Text(
+            text = if (selectedTab == 0) "No models downloaded yet" else "All models downloaded",
+            color = EdgeTextMute, fontSize = 14.sp, fontFamily = appFontFamily,
+          )
+        }
+      } else {
+        LazyColumn(
+          modifier = Modifier.fillMaxSize().padding(horizontal = 16.dp),
+          contentPadding = androidx.compose.foundation.layout.PaddingValues(vertical = 16.dp),
+          verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+          items(displayModels, key = { it.name }) { model ->
+            RealModelRow(
+              model = model,
+              isActive = mmState.selectedModel.name == model.name,
+              downloadStatus = mmState.modelDownloadStatus[model.name],
+              isInstalled = selectedTab == 0,
+              onSelect = { onModelSelected(model) },
+              onDownload = {
+                if (llmTask != null) modelManagerViewModel.downloadModel(llmTask, model)
+              },
+              onCancel = { modelManagerViewModel.cancelDownloadModel(model) },
+              onDelete = { modelManagerViewModel.deleteModel(model) },
+            )
+          }
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun RealModelRow(
+  model: Model,
+  isActive: Boolean,
+  downloadStatus: com.google.ai.edge.gallery.data.ModelDownloadStatus?,
+  isInstalled: Boolean,
+  onSelect: () -> Unit,
+  onDownload: () -> Unit,
+  onCancel: () -> Unit,
+  onDelete: () -> Unit,
+) {
+  val displayName = model.displayName.ifEmpty { model.name }
+  val abbrev = displayName.take(3).uppercase()
+  val sizeGb = if (model.sizeInBytes > 0) "%.1f GB".format(model.sizeInBytes / 1_000_000_000.0) else "?"
+  val isDownloading = downloadStatus?.status == ModelDownloadStatusType.IN_PROGRESS
+  val downloadProgress = if (isDownloading && (downloadStatus?.totalBytes ?: 0L) > 0L)
+    downloadStatus!!.receivedBytes.toFloat() / downloadStatus.totalBytes else 0f
+  var showDeleteConfirm by remember { mutableStateOf(false) }
+
+  if (showDeleteConfirm) {
+    AlertDialog(
+      onDismissRequest = { showDeleteConfirm = false },
+      containerColor = EdgeSurface,
+      titleContentColor = EdgeText,
+      textContentColor = EdgeTextDim,
+      title = { Text(text = "Delete $displayName?", fontFamily = appFontFamily, fontWeight = FontWeight.Bold) },
+      text = {
+        Text(
+          text = if (isActive)
+            "This is your active model. Deleting it will require downloading again before you can use it."
+          else
+            "This will permanently remove the model files (${sizeGb}) from your device.",
+          fontFamily = appFontFamily,
+          fontSize = 14.sp,
+        )
+      },
+      confirmButton = {
+        Box(
+          modifier = Modifier
+            .clip(RoundedCornerShape(8.dp))
+            .background(Color(0xFF3D1A1A))
+            .border(1.dp, Color(0xFF7A2020), RoundedCornerShape(8.dp))
+            .clickable { showDeleteConfirm = false; onDelete() }
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        ) { Text(text = "Delete", color = Color(0xFFFF5555), fontSize = 13.sp, fontFamily = appFontFamily, fontWeight = FontWeight.SemiBold) }
+      },
+      dismissButton = {
+        Box(
+          modifier = Modifier
+            .clip(RoundedCornerShape(8.dp))
+            .background(EdgeSurface2)
+            .border(1.dp, EdgeBorderStrong, RoundedCornerShape(8.dp))
+            .clickable { showDeleteConfirm = false }
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        ) { Text(text = "Cancel", color = EdgeTextDim, fontSize = 13.sp, fontFamily = appFontFamily) }
+      },
+    )
+  }
+
+  Box(
+    modifier = Modifier
+      .fillMaxWidth()
+      .clip(RoundedCornerShape(EdgeRadius))
+      .background(if (isActive) EdgeAccentSoft else EdgeSurface)
+      .border(width = if (isActive) 1.5.dp else 1.dp, color = if (isActive) EdgeAccent else EdgeBorderStrong, shape = RoundedCornerShape(EdgeRadius))
+      .clickable(enabled = isInstalled, onClick = onSelect)
+      .padding(16.dp),
+  ) {
+    Column {
+      Row(verticalAlignment = Alignment.CenterVertically) {
+        Box(
+          modifier = Modifier.size(44.dp).clip(RoundedCornerShape(10.dp))
+            .background(EdgeSurface2).border(1.dp, EdgeBorderStrong, RoundedCornerShape(10.dp)),
+          contentAlignment = Alignment.Center,
+        ) {
+          Text(text = abbrev, color = EdgeAccent, fontSize = 11.sp, fontFamily = FontFamily.Monospace, fontWeight = FontWeight.Bold)
+        }
+        Spacer(Modifier.width(14.dp))
+        Column(modifier = Modifier.weight(1f)) {
+          Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text(text = displayName, color = EdgeText, fontSize = 15.sp, fontFamily = appFontFamily, fontWeight = FontWeight.SemiBold)
+            if (isActive) {
+              Box(
+                modifier = Modifier.clip(RoundedCornerShape(4.dp)).background(EdgeAccentSoft)
+                  .border(1.dp, EdgeAccentBorder, RoundedCornerShape(4.dp)).padding(horizontal = 6.dp, vertical = 2.dp),
+              ) { Text(text = "Active", color = EdgeAccent, fontSize = 9.sp, fontFamily = FontFamily.Monospace) }
+            }
+          }
+          Spacer(Modifier.height(4.dp))
+          Text(text = sizeGb, color = EdgeTextMute, fontSize = 11.sp, fontFamily = FontFamily.Monospace)
+        }
+        Spacer(Modifier.width(8.dp))
+        when {
+          isDownloading -> {
+            Row(
+              verticalAlignment = Alignment.CenterVertically,
+              horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+              Text(
+                text = "${(downloadProgress * 100).toInt()}%",
+                color = EdgeAccent, fontSize = 11.sp, fontFamily = FontFamily.Monospace,
+              )
+              Box(
+                modifier = Modifier
+                  .clip(RoundedCornerShape(8.dp))
+                  .background(EdgeSurface2)
+                  .border(1.dp, EdgeBorderStrong, RoundedCornerShape(8.dp))
+                  .clickable(onClick = onCancel)
+                  .padding(horizontal = 10.dp, vertical = 6.dp),
+              ) {
+                Text(text = "Cancel", color = EdgeTextDim, fontSize = 11.sp, fontFamily = appFontFamily)
+              }
+            }
+          }
+          !isInstalled -> {
+            Box(
+              modifier = Modifier.clip(RoundedCornerShape(8.dp)).background(EdgeAccent)
+                .clickable(onClick = onDownload).padding(horizontal = 12.dp, vertical = 6.dp),
+            ) { Text(text = "Download", color = Color.Black, fontSize = 12.sp, fontFamily = appFontFamily, fontWeight = FontWeight.Bold) }
+          }
+          isInstalled -> {
+            Box(
+              modifier = Modifier.clip(RoundedCornerShape(8.dp)).background(EdgeSurface2)
+                .border(1.dp, EdgeBorderStrong, RoundedCornerShape(8.dp))
+                .clickable { showDeleteConfirm = true }
+                .padding(horizontal = 12.dp, vertical = 6.dp),
+            ) { Text(text = "Delete", color = EdgeTextDim, fontSize = 12.sp, fontFamily = appFontFamily) }
+          }
+        }
+      }
+      if (isDownloading) {
+        Spacer(Modifier.height(10.dp))
+        LinearProgressIndicator(
+          progress = { downloadProgress },
+          modifier = Modifier.fillMaxWidth().height(3.dp).clip(RoundedCornerShape(2.dp)),
+          color = EdgeAccent,
+          trackColor = EdgeSurface2,
+        )
+      }
+    }
+  }
+}

--- a/Android/src/app/src/main/java/com/google/ai/edge/gallery/ui/edgeai/EdgeOnboarding.kt
+++ b/Android/src/app/src/main/java/com/google/ai/edge/gallery/ui/edgeai/EdgeOnboarding.kt
@@ -1,0 +1,537 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.ai.edge.gallery.ui.edgeai
+
+import android.content.Context
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.runtime.collectAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.google.ai.edge.gallery.data.Model
+import com.google.ai.edge.gallery.data.ModelDownloadStatusType
+import com.google.ai.edge.gallery.data.BuiltInTaskId
+import com.google.ai.edge.gallery.ui.modelmanager.ModelManagerViewModel
+import com.google.ai.edge.gallery.ui.theme.appFontFamily
+import kotlinx.coroutines.delay
+
+private const val PREFS_NAME = "edgeai-prefs"
+private const val PREF_BOOTED = "edgeai-booted"
+
+private val DOWNLOAD_LOG_LINES = listOf(
+  "Fetching manifest...",
+  "Resolving shards...",
+  "Downloading weights...",
+  "Verifying checksums...",
+  "Warming up runtime...",
+  "Model ready.",
+)
+
+fun markOnboarded(context: Context) {
+  context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    .edit().putBoolean(PREF_BOOTED, true).apply()
+}
+
+fun isOnboarded(context: Context): Boolean =
+  context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    .getBoolean(PREF_BOOTED, false)
+
+@Composable
+fun EdgeOnboarding(
+  modelManagerViewModel: ModelManagerViewModel,
+  onDone: () -> Unit,
+) {
+  val context = LocalContext.current
+  val mmState by modelManagerViewModel.uiState.collectAsState()
+  var step by remember { mutableIntStateOf(1) }
+
+  // Get real LLM models from the allowlist
+  val llmModels = remember(mmState.tasks) {
+    mmState.tasks.find { it.id == BuiltInTaskId.LLM_CHAT }?.models?.filter { it.isLlm }
+      ?: emptyList()
+  }
+  var selectedModel by remember { mutableStateOf<Model?>(null) }
+
+  // Auto-select first model when list loads
+  LaunchedEffect(llmModels) {
+    if (selectedModel == null && llmModels.isNotEmpty()) {
+      selectedModel = llmModels.first()
+    }
+  }
+
+  Box(
+    modifier = Modifier
+      .fillMaxSize()
+      .background(EdgeBg)
+      .windowInsetsPadding(WindowInsets.statusBars)
+      .windowInsetsPadding(WindowInsets.navigationBars)
+  ) {
+    AnimatedContent(
+      targetState = step,
+      transitionSpec = { fadeIn(tween(300)) togetherWith fadeOut(tween(300)) },
+      label = "OnboardingStep",
+    ) { currentStep ->
+      when (currentStep) {
+        1 -> OnboardingStep1(onNext = { step = 2 })
+        2 -> OnboardingStep2(
+          models = llmModels,
+          loadingModels = mmState.loadingModelAllowlist,
+          selectedModel = selectedModel,
+          onSelect = { selectedModel = it },
+          onNext = { step = 3 },
+        )
+        3 -> OnboardingStep3(
+          model = selectedModel,
+          modelManagerViewModel = modelManagerViewModel,
+          mmState = mmState,
+          onDone = {
+            markOnboarded(context)
+            onDone()
+          },
+        )
+        else -> OnboardingStep1(onNext = { step = 2 })
+      }
+    }
+  }
+}
+
+// ── Step 1: Welcome ──────────────────────────────────────────────────────────
+
+@Composable
+private fun OnboardingStep1(onNext: () -> Unit) {
+  Column(
+    modifier = Modifier
+      .fillMaxSize()
+      .verticalScroll(rememberScrollState())
+      .padding(horizontal = 28.dp, vertical = 32.dp),
+    horizontalAlignment = Alignment.CenterHorizontally,
+  ) {
+    Spacer(Modifier.height(32.dp))
+
+    EdgeMarkLogo(size = 64.dp)
+
+    Spacer(Modifier.height(12.dp))
+
+    Text(
+      text = "edge · ai",
+      color = EdgeTextMute,
+      fontSize = 13.sp,
+      fontFamily = FontFamily.Monospace,
+      letterSpacing = 3.sp,
+    )
+
+    Spacer(Modifier.height(48.dp))
+
+    Text(
+      text = "Your model.\nYour device.\nYour data.",
+      color = EdgeText,
+      fontSize = 36.sp,
+      fontFamily = appFontFamily,
+      fontWeight = FontWeight.Bold,
+      lineHeight = 44.sp,
+      textAlign = TextAlign.Center,
+    )
+
+    Spacer(Modifier.height(20.dp))
+
+    Text(
+      text = "Run state-of-the-art language models entirely on your Android device. No internet required. No data ever leaves your phone.",
+      color = EdgeTextDim,
+      fontSize = 15.sp,
+      fontFamily = appFontFamily,
+      lineHeight = 22.sp,
+      textAlign = TextAlign.Center,
+    )
+
+    Spacer(Modifier.height(40.dp))
+
+    BulletList(
+      items = listOf(
+        Pair("Offline-first", "Full capability with zero connectivity"),
+        Pair("On your hardware", "Uses your device's GPU & NPU directly"),
+        Pair("Open models", "Built on open weights you can trust"),
+      )
+    )
+
+    Spacer(Modifier.weight(1f))
+    Spacer(Modifier.height(40.dp))
+
+    PrimaryButton(text = "Get started →", onClick = onNext)
+  }
+}
+
+// ── Step 2: Model pick (real models) ────────────────────────────────────────
+
+@Composable
+private fun OnboardingStep2(
+  models: List<Model>,
+  loadingModels: Boolean,
+  selectedModel: Model?,
+  onSelect: (Model) -> Unit,
+  onNext: () -> Unit,
+) {
+  Column(
+    modifier = Modifier
+      .fillMaxSize()
+      .verticalScroll(rememberScrollState())
+      .padding(horizontal = 24.dp, vertical = 32.dp),
+  ) {
+    Text(
+      text = "Pick a model",
+      color = EdgeText,
+      fontSize = 26.sp,
+      fontFamily = appFontFamily,
+      fontWeight = FontWeight.Bold,
+    )
+
+    Spacer(Modifier.height(6.dp))
+
+    Text(
+      text = "You can change this later.",
+      color = EdgeTextDim,
+      fontSize = 14.sp,
+      fontFamily = appFontFamily,
+    )
+
+    Spacer(Modifier.height(24.dp))
+
+    if (loadingModels) {
+      Text(
+        text = "Loading models…",
+        color = EdgeTextMute,
+        fontSize = 13.sp,
+        fontFamily = FontFamily.Monospace,
+      )
+    } else {
+      models.forEach { model ->
+        OnboardingModelRow(
+          model = model,
+          selected = model.name == selectedModel?.name,
+          onClick = { onSelect(model) },
+        )
+        Spacer(Modifier.height(10.dp))
+      }
+    }
+
+    Spacer(Modifier.height(24.dp))
+
+    PrimaryButton(
+      text = "Download & continue →",
+      onClick = onNext,
+    )
+  }
+}
+
+@Composable
+private fun OnboardingModelRow(
+  model: Model,
+  selected: Boolean,
+  onClick: () -> Unit,
+) {
+  val displayName = model.displayName.ifEmpty { model.name }
+  val abbrev = displayName.take(3).uppercase()
+  val sizeGb = if (model.sizeInBytes > 0)
+    "%.1f GB".format(model.sizeInBytes / 1_000_000_000.0) else "?"
+
+  val borderColor = if (selected) EdgeAccent else EdgeBorderStrong
+  Box(
+    modifier = Modifier
+      .fillMaxWidth()
+      .clip(RoundedCornerShape(EdgeRadius))
+      .border(width = if (selected) 1.5.dp else 1.dp, color = borderColor, shape = RoundedCornerShape(EdgeRadius))
+      .background(if (selected) EdgeAccentSoft else EdgeSurface)
+      .clickable(onClick = onClick)
+      .padding(16.dp),
+  ) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+      Box(
+        modifier = Modifier
+          .size(44.dp)
+          .clip(RoundedCornerShape(10.dp))
+          .background(EdgeSurface2)
+          .border(1.dp, EdgeBorderStrong, RoundedCornerShape(10.dp)),
+        contentAlignment = Alignment.Center,
+      ) {
+        Text(text = abbrev, color = EdgeAccent, fontSize = 11.sp, fontFamily = FontFamily.Monospace, fontWeight = FontWeight.Bold)
+      }
+      Spacer(Modifier.width(14.dp))
+      Column(modifier = Modifier.weight(1f)) {
+        Text(text = displayName, color = EdgeText, fontSize = 15.sp, fontFamily = appFontFamily, fontWeight = FontWeight.SemiBold)
+        Spacer(Modifier.height(4.dp))
+        if (model.info.isNotEmpty()) {
+          Text(text = model.info.take(60), color = EdgeTextDim, fontSize = 12.sp, fontFamily = appFontFamily, maxLines = 1)
+          Spacer(Modifier.height(4.dp))
+        }
+        Text(text = sizeGb, color = EdgeTextMute, fontSize = 11.sp, fontFamily = FontFamily.Monospace)
+      }
+    }
+  }
+}
+
+// ── Step 3: Download (real) ──────────────────────────────────────────────────
+
+@Composable
+private fun OnboardingStep3(
+  model: Model?,
+  modelManagerViewModel: ModelManagerViewModel,
+  mmState: com.google.ai.edge.gallery.ui.modelmanager.ModelManagerUiState,
+  onDone: () -> Unit,
+) {
+  val context = LocalContext.current
+  val llmTask = mmState.tasks.find { it.id == BuiltInTaskId.LLM_CHAT }
+  val downloadStatus = model?.let { mmState.modelDownloadStatus[it.name] }
+  val modelName = model?.displayName?.ifEmpty { model.name } ?: "Model"
+
+  val progress = if (downloadStatus != null && downloadStatus.totalBytes > 0) {
+    downloadStatus.receivedBytes.toFloat() / downloadStatus.totalBytes
+  } else 0f
+
+  val phase = when (downloadStatus?.status) {
+    ModelDownloadStatusType.IN_PROGRESS -> "Downloading weights"
+    ModelDownloadStatusType.UNZIPPING -> "Extracting model"
+    ModelDownloadStatusType.SUCCEEDED -> "Model ready"
+    ModelDownloadStatusType.FAILED -> "Download failed"
+    else -> "Preparing…"
+  }
+
+  val logLines = DOWNLOAD_LOG_LINES.take(
+    when (downloadStatus?.status) {
+      ModelDownloadStatusType.IN_PROGRESS -> (progress * DOWNLOAD_LOG_LINES.size).toInt().coerceAtLeast(1)
+      ModelDownloadStatusType.SUCCEEDED -> DOWNLOAD_LOG_LINES.size
+      else -> 1
+    }
+  )
+
+  // Start download when entering this step
+  LaunchedEffect(model?.name) {
+    if (model != null && llmTask != null) {
+      val status = mmState.modelDownloadStatus[model.name]?.status
+      if (status != ModelDownloadStatusType.SUCCEEDED && status != ModelDownloadStatusType.IN_PROGRESS) {
+        modelManagerViewModel.downloadModel(llmTask, model)
+      }
+    }
+  }
+
+  // Advance when download completes
+  LaunchedEffect(downloadStatus?.status) {
+    if (downloadStatus?.status == ModelDownloadStatusType.SUCCEEDED) {
+      delay(800)
+      onDone()
+    }
+  }
+
+  Column(
+    modifier = Modifier
+      .fillMaxSize()
+      .padding(horizontal = 28.dp, vertical = 48.dp),
+    horizontalAlignment = Alignment.CenterHorizontally,
+  ) {
+    Spacer(Modifier.height(32.dp))
+
+    EdgeMarkLogo(size = 56.dp)
+
+    Spacer(Modifier.height(32.dp))
+
+    Text(
+      text = modelName,
+      color = EdgeText,
+      fontSize = 22.sp,
+      fontFamily = appFontFamily,
+      fontWeight = FontWeight.Bold,
+      textAlign = TextAlign.Center,
+    )
+
+    Spacer(Modifier.height(8.dp))
+
+    Text(
+      text = phase,
+      color = EdgeAccent,
+      fontSize = 13.sp,
+      fontFamily = FontFamily.Monospace,
+      letterSpacing = 1.sp,
+    )
+
+    Spacer(Modifier.height(32.dp))
+
+    // Progress bar
+    Box(
+      modifier = Modifier
+        .fillMaxWidth()
+        .height(6.dp)
+        .clip(RoundedCornerShape(3.dp))
+        .background(EdgeSurface2),
+    ) {
+      Box(
+        modifier = Modifier
+          .fillMaxWidth(fraction = progress)
+          .height(6.dp)
+          .background(EdgeAccent),
+      )
+    }
+
+    Spacer(Modifier.height(8.dp))
+
+    Text(
+      text = "${(progress * 100).toInt()}%",
+      color = EdgeTextMute,
+      fontSize = 12.sp,
+      fontFamily = FontFamily.Monospace,
+    )
+
+    Spacer(Modifier.height(32.dp))
+
+    // Log lines
+    Column(
+      modifier = Modifier
+        .fillMaxWidth()
+        .clip(RoundedCornerShape(EdgeRadiusSm))
+        .background(EdgeSurface)
+        .border(1.dp, EdgeBorder, RoundedCornerShape(EdgeRadiusSm))
+        .padding(16.dp),
+      verticalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+      logLines.forEach { line ->
+        Text(
+          text = "> $line",
+          color = EdgeTextDim,
+          fontSize = 11.sp,
+          fontFamily = FontFamily.Monospace,
+        )
+      }
+    }
+  }
+}
+
+// ── Shared helpers ────────────────────────────────────────────────────────────
+
+@Composable
+private fun BulletList(items: List<Pair<String, String>>) {
+  Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+    items.forEach { (title, subtitle) ->
+      Row(verticalAlignment = Alignment.Top) {
+        Box(
+          modifier = Modifier
+            .padding(top = 4.dp)
+            .size(8.dp)
+            .clip(RoundedCornerShape(4.dp))
+            .background(EdgeAccent),
+        )
+        Spacer(Modifier.width(14.dp))
+        Column {
+          Text(
+            text = title,
+            color = EdgeText,
+            fontSize = 15.sp,
+            fontFamily = appFontFamily,
+            fontWeight = FontWeight.SemiBold,
+          )
+          Text(
+            text = subtitle,
+            color = EdgeTextDim,
+            fontSize = 13.sp,
+            fontFamily = appFontFamily,
+          )
+        }
+      }
+    }
+  }
+}
+
+@Composable
+fun PrimaryButton(
+  text: String,
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  Box(
+    modifier = modifier
+      .fillMaxWidth()
+      .height(52.dp)
+      .clip(RoundedCornerShape(EdgeRadius))
+      .background(EdgeAccent)
+      .clickable(onClick = onClick),
+    contentAlignment = Alignment.Center,
+  ) {
+    Text(
+      text = text,
+      color = Color.Black,
+      fontSize = 16.sp,
+      fontFamily = appFontFamily,
+      fontWeight = FontWeight.Bold,
+    )
+  }
+}
+
+@Composable
+fun TagChip(text: String) {
+  Box(
+    modifier = Modifier
+      .clip(RoundedCornerShape(4.dp))
+      .background(EdgeSurface2)
+      .border(1.dp, EdgeBorderStrong, RoundedCornerShape(4.dp))
+      .padding(horizontal = 6.dp, vertical = 2.dp),
+  ) {
+    Text(
+      text = text,
+      color = EdgeTextDim,
+      fontSize = 10.sp,
+      fontFamily = appFontFamily,
+    )
+  }
+}

--- a/Android/src/app/src/main/java/com/google/ai/edge/gallery/ui/edgeai/EdgeSettings.kt
+++ b/Android/src/app/src/main/java/com/google/ai/edge/gallery/ui/edgeai/EdgeSettings.kt
@@ -1,0 +1,372 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.ai.edge.gallery.ui.edgeai
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Slider
+import androidx.compose.material3.SliderDefaults
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.google.ai.edge.gallery.ui.theme.appFontFamily
+
+@Composable
+fun EdgeSettings(onBack: () -> Unit) {
+  var temperature by remember { mutableFloatStateOf(0.7f) }
+  var topP by remember { mutableFloatStateOf(0.9f) }
+  var maxTokens by remember { mutableFloatStateOf(512f) }
+  var streamTokens by remember { mutableStateOf(true) }
+  var keepWarm by remember { mutableStateOf(false) }
+  var offlineOnly by remember { mutableStateOf(true) }
+  var encryptHistory by remember { mutableStateOf(false) }
+
+  Box(
+    modifier = Modifier
+      .fillMaxSize()
+      .background(EdgeBg)
+      .windowInsetsPadding(WindowInsets.statusBars)
+      .windowInsetsPadding(WindowInsets.navigationBars)
+  ) {
+    Column(modifier = Modifier.fillMaxSize()) {
+      // Header
+      Row(
+        modifier = Modifier
+          .fillMaxWidth()
+          .height(56.dp)
+          .padding(horizontal = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+      ) {
+        IconButton(onClick = onBack) {
+          Icon(
+            imageVector = Icons.Default.ArrowBack,
+            contentDescription = "Back",
+            tint = EdgeTextDim,
+          )
+        }
+        Text(
+          text = "Settings",
+          color = EdgeText,
+          fontSize = 18.sp,
+          fontFamily = appFontFamily,
+          fontWeight = FontWeight.Bold,
+        )
+      }
+
+      Column(
+        modifier = Modifier
+          .weight(1f)
+          .verticalScroll(rememberScrollState())
+          .padding(horizontal = 16.dp),
+      ) {
+        // ── Generation ──────────────────────────────────────────────────────
+        SectionHeader("Generation")
+
+        SettingsCard {
+          SliderRow(
+            label = "Temperature",
+            value = temperature,
+            valueRange = 0f..2f,
+            displayValue = "%.2f".format(temperature),
+            onValueChange = { temperature = it },
+          )
+
+          SettingsDivider()
+
+          SliderRow(
+            label = "Top-p",
+            value = topP,
+            valueRange = 0f..1f,
+            displayValue = "%.2f".format(topP),
+            onValueChange = { topP = it },
+          )
+
+          SettingsDivider()
+
+          SliderRow(
+            label = "Max tokens",
+            value = maxTokens,
+            valueRange = 64f..4096f,
+            displayValue = maxTokens.toInt().toString(),
+            onValueChange = { maxTokens = it },
+          )
+        }
+
+        Spacer(Modifier.height(20.dp))
+
+        // ── Runtime ────────────────────────────────────────────────────────
+        SectionHeader("Runtime")
+
+        SettingsCard {
+          PickerRow(
+            label = "Accelerator",
+            value = "GPU",
+          )
+
+          SettingsDivider()
+
+          ToggleRow(
+            label = "Stream tokens",
+            subLabel = "Show responses as they generate",
+            checked = streamTokens,
+            onCheckedChange = { streamTokens = it },
+          )
+
+          SettingsDivider()
+
+          ToggleRow(
+            label = "Keep warm",
+            subLabel = "Keep model loaded between chats",
+            checked = keepWarm,
+            onCheckedChange = { keepWarm = it },
+          )
+        }
+
+        Spacer(Modifier.height(20.dp))
+
+        // ── Privacy ────────────────────────────────────────────────────────
+        SectionHeader("Privacy")
+
+        SettingsCard {
+          ToggleRow(
+            label = "Offline only",
+            subLabel = "Disable all network access (locked)",
+            checked = offlineOnly,
+            onCheckedChange = { /* locked */ },
+            locked = true,
+          )
+
+          SettingsDivider()
+
+          ToggleRow(
+            label = "Encrypt history",
+            subLabel = "AES-256 encryption for stored chats",
+            checked = encryptHistory,
+            onCheckedChange = { encryptHistory = it },
+          )
+        }
+
+        Spacer(Modifier.height(32.dp))
+
+        // Footer
+        Text(
+          text = "edge ai · v1.0.3 · build 241",
+          color = EdgeTextMute,
+          fontSize = 11.sp,
+          fontFamily = FontFamily.Monospace,
+          modifier = Modifier.align(Alignment.CenterHorizontally),
+        )
+
+        Spacer(Modifier.height(24.dp))
+      }
+    }
+  }
+}
+
+@Composable
+private fun SectionHeader(text: String) {
+  Text(
+    text = text.uppercase(),
+    color = EdgeTextMute,
+    fontSize = 10.sp,
+    fontFamily = FontFamily.Monospace,
+    letterSpacing = 2.sp,
+    modifier = Modifier.padding(bottom = 8.dp, top = 4.dp),
+  )
+}
+
+@Composable
+private fun SettingsCard(content: @Composable () -> Unit) {
+  Column(
+    modifier = Modifier
+      .fillMaxWidth()
+      .clip(RoundedCornerShape(EdgeRadius))
+      .background(EdgeSurface)
+      .border(1.dp, EdgeBorderStrong, RoundedCornerShape(EdgeRadius))
+      .padding(horizontal = 16.dp, vertical = 4.dp),
+  ) {
+    content()
+  }
+}
+
+@Composable
+private fun SettingsDivider() {
+  Box(
+    modifier = Modifier
+      .fillMaxWidth()
+      .height(1.dp)
+      .background(EdgeBorderStrong)
+  )
+}
+
+@Composable
+private fun SliderRow(
+  label: String,
+  value: Float,
+  valueRange: ClosedFloatingPointRange<Float>,
+  displayValue: String,
+  onValueChange: (Float) -> Unit,
+) {
+  Column(modifier = Modifier.padding(vertical = 12.dp)) {
+    Row(
+      modifier = Modifier.fillMaxWidth(),
+      horizontalArrangement = Arrangement.SpaceBetween,
+      verticalAlignment = Alignment.CenterVertically,
+    ) {
+      Text(
+        text = label,
+        color = EdgeText,
+        fontSize = 14.sp,
+        fontFamily = appFontFamily,
+      )
+      Text(
+        text = displayValue,
+        color = EdgeAccent,
+        fontSize = 13.sp,
+        fontFamily = FontFamily.Monospace,
+        fontWeight = FontWeight.SemiBold,
+      )
+    }
+    Slider(
+      value = value,
+      onValueChange = onValueChange,
+      valueRange = valueRange,
+      modifier = Modifier.fillMaxWidth(),
+      colors = SliderDefaults.colors(
+        thumbColor = EdgeAccent,
+        activeTrackColor = EdgeAccent,
+        inactiveTrackColor = EdgeSurface2,
+      ),
+    )
+  }
+}
+
+@Composable
+private fun ToggleRow(
+  label: String,
+  subLabel: String,
+  checked: Boolean,
+  onCheckedChange: (Boolean) -> Unit,
+  locked: Boolean = false,
+) {
+  Row(
+    modifier = Modifier
+      .fillMaxWidth()
+      .padding(vertical = 14.dp),
+    verticalAlignment = Alignment.CenterVertically,
+  ) {
+    Column(modifier = Modifier.weight(1f)) {
+      Text(
+        text = label,
+        color = if (locked) EdgeTextDim else EdgeText,
+        fontSize = 14.sp,
+        fontFamily = appFontFamily,
+      )
+      Text(
+        text = subLabel,
+        color = EdgeTextMute,
+        fontSize = 12.sp,
+        fontFamily = appFontFamily,
+      )
+    }
+    Switch(
+      checked = checked,
+      onCheckedChange = if (locked) null else onCheckedChange,
+      enabled = !locked,
+      colors = SwitchDefaults.colors(
+        checkedThumbColor = Color.Black,
+        checkedTrackColor = EdgeAccent,
+        uncheckedThumbColor = EdgeTextDim,
+        uncheckedTrackColor = EdgeSurface2,
+        disabledCheckedTrackColor = EdgeAccent.copy(alpha = 0.5f),
+        disabledCheckedThumbColor = Color.Black,
+      ),
+    )
+  }
+}
+
+@Composable
+private fun PickerRow(
+  label: String,
+  value: String,
+) {
+  Row(
+    modifier = Modifier
+      .fillMaxWidth()
+      .padding(vertical = 14.dp),
+    verticalAlignment = Alignment.CenterVertically,
+  ) {
+    Text(
+      text = label,
+      color = EdgeText,
+      fontSize = 14.sp,
+      fontFamily = appFontFamily,
+      modifier = Modifier.weight(1f),
+    )
+    Box(
+      modifier = Modifier
+        .clip(RoundedCornerShape(6.dp))
+        .background(EdgeSurface2)
+        .border(1.dp, EdgeBorderStrong, RoundedCornerShape(6.dp))
+        .padding(horizontal = 12.dp, vertical = 6.dp),
+    ) {
+      Text(
+        text = value,
+        color = EdgeAccent,
+        fontSize = 12.sp,
+        fontFamily = FontFamily.Monospace,
+        fontWeight = FontWeight.SemiBold,
+      )
+    }
+  }
+}

--- a/Android/src/app/src/main/java/com/google/ai/edge/gallery/ui/edgeai/EdgeVoiceMode.kt
+++ b/Android/src/app/src/main/java/com/google/ai/edge/gallery/ui/edgeai/EdgeVoiceMode.kt
@@ -1,0 +1,284 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.ai.edge.gallery.ui.edgeai
+
+import androidx.compose.animation.core.EaseInOut
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Mic
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.google.ai.edge.gallery.ui.theme.appFontFamily
+
+@Composable
+fun EdgeVoiceMode(onDismiss: () -> Unit) {
+  val infiniteTransition = rememberInfiniteTransition(label = "voiceRings")
+
+  // 5 rings with staggered animations
+  val ring1Scale by infiniteTransition.animateFloat(
+    initialValue = 1f, targetValue = 1.25f,
+    animationSpec = infiniteRepeatable(tween(1200, easing = EaseInOut), RepeatMode.Reverse),
+    label = "r1",
+  )
+  val ring2Scale by infiniteTransition.animateFloat(
+    initialValue = 1f, targetValue = 1.4f,
+    animationSpec = infiniteRepeatable(tween(1400, delayMillis = 100, easing = EaseInOut), RepeatMode.Reverse),
+    label = "r2",
+  )
+  val ring3Scale by infiniteTransition.animateFloat(
+    initialValue = 1f, targetValue = 1.55f,
+    animationSpec = infiniteRepeatable(tween(1600, delayMillis = 200, easing = EaseInOut), RepeatMode.Reverse),
+    label = "r3",
+  )
+  val ring4Scale by infiniteTransition.animateFloat(
+    initialValue = 1f, targetValue = 1.7f,
+    animationSpec = infiniteRepeatable(tween(1800, delayMillis = 300, easing = EaseInOut), RepeatMode.Reverse),
+    label = "r4",
+  )
+  val ring5Scale by infiniteTransition.animateFloat(
+    initialValue = 1f, targetValue = 1.85f,
+    animationSpec = infiniteRepeatable(tween(2000, delayMillis = 400, easing = EaseInOut), RepeatMode.Reverse),
+    label = "r5",
+  )
+
+  // Waveform bars animation
+  val waveAlpha by infiniteTransition.animateFloat(
+    initialValue = 0.4f, targetValue = 1f,
+    animationSpec = infiniteRepeatable(tween(600, easing = LinearEasing), RepeatMode.Reverse),
+    label = "wave",
+  )
+
+  Box(
+    modifier = Modifier
+      .fillMaxSize()
+      .background(EdgeBg)
+      .windowInsetsPadding(WindowInsets.statusBars)
+      .windowInsetsPadding(WindowInsets.navigationBars),
+    contentAlignment = Alignment.Center,
+  ) {
+    Column(
+      horizontalAlignment = Alignment.CenterHorizontally,
+      modifier = Modifier.fillMaxSize(),
+    ) {
+      Spacer(Modifier.height(24.dp))
+
+      // LISTENING chip
+      Box(
+        modifier = Modifier
+          .clip(RoundedCornerShape(50.dp))
+          .background(EdgeAccentSoft)
+          .border(1.dp, EdgeAccentBorder, RoundedCornerShape(50.dp))
+          .padding(horizontal = 18.dp, vertical = 8.dp),
+      ) {
+        Row(
+          verticalAlignment = Alignment.CenterVertically,
+          horizontalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+          Box(
+            modifier = Modifier
+              .size(6.dp)
+              .clip(CircleShape)
+              .background(EdgeAccent)
+          )
+          Text(
+            text = "LISTENING",
+            color = EdgeAccent,
+            fontSize = 11.sp,
+            fontFamily = FontFamily.Monospace,
+            letterSpacing = 2.sp,
+            fontWeight = FontWeight.Bold,
+          )
+        }
+      }
+
+      Spacer(Modifier.weight(1f))
+
+      // Animated concentric rings around central orb
+      Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier.size(260.dp),
+      ) {
+        // Rings (outermost first)
+        Box(
+          modifier = Modifier
+            .size(220.dp)
+            .scale(ring5Scale)
+            .clip(CircleShape)
+            .border(1.dp, EdgeAccent.copy(alpha = 0.05f), CircleShape),
+        )
+        Box(
+          modifier = Modifier
+            .size(190.dp)
+            .scale(ring4Scale)
+            .clip(CircleShape)
+            .border(1.dp, EdgeAccent.copy(alpha = 0.09f), CircleShape),
+        )
+        Box(
+          modifier = Modifier
+            .size(160.dp)
+            .scale(ring3Scale)
+            .clip(CircleShape)
+            .border(1.dp, EdgeAccent.copy(alpha = 0.14f), CircleShape),
+        )
+        Box(
+          modifier = Modifier
+            .size(130.dp)
+            .scale(ring2Scale)
+            .clip(CircleShape)
+            .border(1.5.dp, EdgeAccent.copy(alpha = 0.22f), CircleShape),
+        )
+        Box(
+          modifier = Modifier
+            .size(100.dp)
+            .scale(ring1Scale)
+            .clip(CircleShape)
+            .border(1.5.dp, EdgeAccent.copy(alpha = 0.35f), CircleShape),
+        )
+
+        // Central orb
+        Box(
+          modifier = Modifier
+            .size(72.dp)
+            .clip(CircleShape)
+            .background(EdgeAccentSoft)
+            .border(2.dp, EdgeAccent, CircleShape),
+          contentAlignment = Alignment.Center,
+        ) {
+          Icon(
+            imageVector = Icons.Default.Mic,
+            contentDescription = "Mic",
+            tint = EdgeAccent,
+            modifier = Modifier.size(28.dp),
+          )
+        }
+      }
+
+      Spacer(Modifier.height(32.dp))
+
+      // Transcript area
+      Text(
+        text = "Listening…",
+        color = EdgeTextDim,
+        fontSize = 15.sp,
+        fontFamily = appFontFamily,
+        textAlign = TextAlign.Center,
+        modifier = Modifier.padding(horizontal = 40.dp),
+      )
+
+      Spacer(Modifier.weight(1f))
+
+      // Bottom controls
+      Row(
+        modifier = Modifier
+          .fillMaxWidth()
+          .padding(horizontal = 48.dp, vertical = 32.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+      ) {
+        // Pause
+        Box(
+          modifier = Modifier
+            .size(52.dp)
+            .clip(CircleShape)
+            .background(EdgeSurface)
+            .border(1.dp, EdgeBorderStrong, CircleShape)
+            .clickable { },
+          contentAlignment = Alignment.Center,
+        ) {
+          Text(text = "⏸", fontSize = 20.sp)
+        }
+
+        // STOP (larger)
+        Box(
+          modifier = Modifier
+            .size(68.dp)
+            .clip(CircleShape)
+            .background(EdgeAccent)
+            .clickable(onClick = onDismiss),
+          contentAlignment = Alignment.Center,
+        ) {
+          Text(
+            text = "STOP",
+            color = Color.Black,
+            fontSize = 12.sp,
+            fontFamily = FontFamily.Monospace,
+            fontWeight = FontWeight.ExtraBold,
+            letterSpacing = 1.sp,
+          )
+        }
+
+        // Waveform (decorative)
+        Row(
+          modifier = Modifier
+            .size(52.dp)
+            .clip(CircleShape)
+            .background(EdgeSurface)
+            .border(1.dp, EdgeBorderStrong, CircleShape),
+          horizontalArrangement = Arrangement.Center,
+          verticalAlignment = Alignment.CenterVertically,
+        ) {
+          repeat(5) { i ->
+            val barHeight = (8 + (i % 3) * 6).dp
+            Box(
+              modifier = Modifier
+                .size(width = 3.dp, height = barHeight)
+                .background(EdgeAccent.copy(alpha = waveAlpha * (0.4f + i * 0.12f))),
+            )
+            if (i < 4) Spacer(Modifier.size(2.dp))
+          }
+        }
+      }
+    }
+  }
+}

--- a/Android/src/app/src/main/java/com/google/ai/edge/gallery/ui/navigation/GalleryNavGraph.kt
+++ b/Android/src/app/src/main/java/com/google/ai/edge/gallery/ui/navigation/GalleryNavGraph.kt
@@ -80,6 +80,7 @@ import com.google.ai.edge.gallery.ui.benchmark.BenchmarkScreen
 import com.google.ai.edge.gallery.ui.common.ErrorDialog
 import com.google.ai.edge.gallery.ui.common.ModelPageAppBar
 import com.google.ai.edge.gallery.ui.common.chat.ModelDownloadStatusInfoPanel
+import com.google.ai.edge.gallery.ui.edgeai.EdgeAiEntryPoint
 import com.google.ai.edge.gallery.ui.home.HomeScreen
 import com.google.ai.edge.gallery.ui.home.PromoScreenGm4
 import com.google.ai.edge.gallery.ui.modelmanager.GlobalModelManager
@@ -91,6 +92,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 private const val TAG = "AGGalleryNavGraph"
+private const val ROUTE_EDGE_AI_HOME = "edge_ai_home"
 private const val ROUTE_HOMESCREEN = "homepage"
 private const val ROUTE_MODEL_LIST = "model_list"
 private const val ROUTE_MODEL = "route_model"
@@ -182,10 +184,15 @@ fun GalleryNavHost(
 
   NavHost(
     navController = navController,
-    startDestination = ROUTE_HOMESCREEN,
+    startDestination = ROUTE_EDGE_AI_HOME,
     enterTransition = { EnterTransition.None },
     exitTransition = { ExitTransition.None },
   ) {
+    // Edge AI home (new redesigned UI).
+    composable(route = ROUTE_EDGE_AI_HOME) {
+      EdgeAiEntryPoint(modelManagerViewModel = modelManagerViewModel)
+    }
+
     // Home screen.
     composable(route = ROUTE_HOMESCREEN) {
       // Create a state to trigger PromoScreen fade in animation.

--- a/Android/src/build_and_deploy.bat
+++ b/Android/src/build_and_deploy.bat
@@ -1,0 +1,70 @@
+@echo off
+setlocal enabledelayedexpansion
+
+:: Always run from the directory this script lives in (Android\src)
+cd /d "%~dp0"
+
+set "ADB=C:\Android\Sdk\platform-tools\adb.exe"
+set "APK=app\build\outputs\apk\debug\app-debug.apk"
+
+echo ============================================
+echo  Edge AI - Build and Deploy
+echo ============================================
+echo.
+
+:: ── Check ADB ────────────────────────────────
+if not exist "%ADB%" (
+  echo [ERROR] ADB not found at %ADB%
+  echo         Install platform-tools or update the ADB path in this script.
+  pause & exit /b 1
+)
+
+:: ── Check device connected ───────────────────
+echo [1/4] Checking USB device...
+"%ADB%" devices | findstr /R "device$" >nul 2>&1
+if errorlevel 1 (
+  echo [ERROR] No Android device detected.
+  echo         - Enable USB Debugging on your phone
+  echo         - Accept the RSA fingerprint prompt on the device
+  echo         - Try a different USB cable / port
+  pause & exit /b 1
+)
+echo       Device found.
+echo.
+
+:: ── Build ─────────────────────────────────────
+echo [2/4] Building debug APK (this takes a few minutes)...
+call "%~dp0gradlew.bat" assembleDebug
+if errorlevel 1 (
+  echo.
+  echo [ERROR] Build failed. Check the output above for details.
+  pause & exit /b 1
+)
+echo.
+echo       Build successful.
+echo.
+
+:: ── Install ───────────────────────────────────
+echo [3/4] Installing APK on device...
+"%ADB%" install -r "%APK%"
+if errorlevel 1 (
+  echo.
+  echo [ERROR] Install failed.
+  echo         If you see INSTALL_FAILED_UPDATE_INCOMPATIBLE, run:
+  echo           %ADB% uninstall com.edge.ai.gallery
+  echo         then run this script again.
+  pause & exit /b 1
+)
+echo.
+echo       Install successful.
+echo.
+
+:: ── Launch ────────────────────────────────────
+echo [4/4] Launching Edge AI...
+"%ADB%" shell am start -n com.edge.ai.gallery/com.google.ai.edge.gallery.MainActivity
+echo.
+echo ============================================
+echo  Done! Edge AI is running on your device.
+echo ============================================
+echo.
+pause

--- a/Android/src/copy_models.bat
+++ b/Android/src/copy_models.bat
@@ -1,0 +1,77 @@
+@echo off
+setlocal enabledelayedexpansion
+
+set "ADB=C:\Android\Sdk\platform-tools\adb.exe"
+set "SRC_PKG=com.google.ai.edge.gallery"
+set "DEST_PKG=com.edge.ai.gallery"
+set "TEMP_DIR=C:\edge_ai_models_temp"
+set "PHONE_STAGING=/sdcard/Download/edge_ai_staging"
+
+echo ============================================
+echo  Edge AI - Copy Models from Google App
+echo ============================================
+echo.
+
+:: ── Check device ─────────────────────────────
+"%ADB%" devices | findstr /R "device$" >nul 2>&1
+if errorlevel 1 (
+  echo [ERROR] No Android device detected.
+  pause & exit /b 1
+)
+
+:: ── Check if already pulled ───────────────────
+if exist "%TEMP_DIR%\files" (
+  echo [INFO] Found previously pulled files at %TEMP_DIR%
+  echo        Skipping pull step.
+  goto :push
+)
+
+:: ── Pull model files to PC ───────────────────
+echo [1/3] Pulling model files from Google app to PC...
+echo       This may take a while for large models.
+echo.
+if exist "%TEMP_DIR%" rd /s /q "%TEMP_DIR%"
+mkdir "%TEMP_DIR%"
+"%ADB%" pull "/sdcard/Android/data/%SRC_PKG%/files/" "%TEMP_DIR%"
+if errorlevel 1 (
+  echo [ERROR] Pull failed.
+  pause & exit /b 1
+)
+
+:push
+echo.
+echo [2/3] Pushing to phone staging area ^(/sdcard/Download^)...
+echo       ^(Android/data is write-protected via ADB, using Download as bridge^)
+echo.
+
+:: Clean up old staging if exists
+"%ADB%" shell rm -rf "%PHONE_STAGING%"
+"%ADB%" shell mkdir -p "%PHONE_STAGING%"
+
+:: Push to Download folder (always ADB-writable)
+"%ADB%" push "%TEMP_DIR%\files\." "%PHONE_STAGING%/"
+if errorlevel 1 (
+  echo [ERROR] Push to staging failed.
+  pause & exit /b 1
+)
+
+echo.
+echo [3/3] Moving from staging into Edge AI app folder...
+"%ADB%" shell "mkdir -p /sdcard/Android/data/%DEST_PKG%/files/ && cp -rn %PHONE_STAGING%/. /sdcard/Android/data/%DEST_PKG%/files/ && rm -rf %PHONE_STAGING%"
+if errorlevel 1 (
+  echo [WARN] Move step had errors - some files may not have copied.
+  echo        Check the Models screen in Edge AI.
+) else (
+  echo.
+  echo Cleaning up PC temp files...
+  rd /s /q "%TEMP_DIR%"
+)
+
+echo.
+echo ============================================
+echo  Done! Open Edge AI - tap the hamburger
+echo  menu, go to Models - the downloaded
+echo  models should show as Installed.
+echo ============================================
+echo.
+pause

--- a/Android/src/copy_models_via_pc.bat
+++ b/Android/src/copy_models_via_pc.bat
@@ -1,0 +1,71 @@
+@echo off
+setlocal enabledelayedexpansion
+
+set "ADB=C:\Android\Sdk\platform-tools\adb.exe"
+set "DEST_PKG=com.edge.ai.gallery"
+set "TEMP_DIR=%TEMP%\edge_ai_models"
+
+echo ============================================
+echo  Edge AI - Copy Models via PC (fallback)
+echo ============================================
+echo.
+
+:: ── Check device ─────────────────────────────
+"%ADB%" devices | findstr /R "device$" >nul 2>&1
+if errorlevel 1 (
+  echo [ERROR] No Android device detected.
+  pause & exit /b 1
+)
+
+:: ── Find source package ───────────────────────
+echo [1/4] Looking for Google AI Edge Gallery...
+set "SRC_PKG="
+for /f "tokens=2 delims=:" %%A in ('"%ADB%" shell pm list packages ^| findstr "edge.gallery"') do (
+  set "CANDIDATE=%%A"
+  set "CANDIDATE=!CANDIDATE: =!"
+  set "CANDIDATE=!CANDIDATE:~0,-1!"
+  if not "!CANDIDATE!"=="%DEST_PKG%" set "SRC_PKG=!CANDIDATE!"
+)
+
+if "!SRC_PKG!"=="" (
+  echo [ERROR] Google AI Edge Gallery not found.
+  pause & exit /b 1
+)
+echo       Found: !SRC_PKG!
+echo.
+
+:: ── Pull to PC ────────────────────────────────
+echo [2/4] Pulling models to PC temp folder...
+echo       %TEMP_DIR%
+if exist "%TEMP_DIR%" rd /s /q "%TEMP_DIR%"
+mkdir "%TEMP_DIR%"
+
+"%ADB%" pull "/sdcard/Android/data/!SRC_PKG!/files/" "%TEMP_DIR%"
+if errorlevel 1 (
+  echo.
+  echo [WARN] adb pull had errors. Trying run-as fallback...
+  "%ADB%" shell run-as !SRC_PKG! tar -c files | "%ADB%" exec-out tar -x -C "%TEMP_DIR%"
+)
+echo.
+
+:: ── Push to our app ───────────────────────────
+echo [3/4] Pushing models to Edge AI...
+"%ADB%" shell mkdir -p "/sdcard/Android/data/%DEST_PKG%/files/"
+"%ADB%" push "%TEMP_DIR%\files\." "/sdcard/Android/data/%DEST_PKG%/files/"
+if errorlevel 1 (
+  echo [ERROR] Push failed.
+  pause & exit /b 1
+)
+echo.
+
+:: ── Cleanup ───────────────────────────────────
+echo [4/4] Cleaning up temp files on PC...
+rd /s /q "%TEMP_DIR%"
+echo.
+
+echo ============================================
+echo  Done! Open Edge AI - models show as
+echo  Installed in the Models screen.
+echo ============================================
+echo.
+pause


### PR DESCRIPTION
- New `ui/edgeai/` package: OLED-dark, orange-accent chat-first UI replacing the original launcher with EdgeAiEntryPoint
- EdgeAiScreen: wires to real ModelManagerViewModel + LlmChatViewModel for live LLM inference, model init, and session management
- EdgeModelHub: shows real downloaded/available models, Download button, Cancel mid-download, Delete with confirmation dialog
- EdgeOnboarding: real model list from allowlist, real download flow
- EdgeChatScreen: message bubbles, streaming text, drawer, voice mode stub
- EdgeSettings, EdgeVoiceMode: settings and voice overlays
- Change applicationId to com.edge.ai.gallery so fork coexists with the Play Store version; keep namespace as com.google.ai.edge.gallery
- App label changed to "Edge AI"
- Add build_and_deploy.bat and copy_models.bat dev scripts