### PR TITLE
Fix chat bubble tail side in RTL layouts

### DIFF
--- a/Android/src/app/src/main/java/com/google/ai/edge/gallery/ui/common/chat/MessageBubbleShape.kt
+++ b/Android/src/app/src/main/java/com/google/ai/edge/gallery/ui/common/chat/MessageBubbleShape.kt
@@ -43,6 +43,10 @@ class MessageBubbleShape(
     density: Density,
   ): Outline {
     val radiusPx = with(density) { radius.toPx() }
+    val isRtl = layoutDirection == LayoutDirection.Rtl
+    // Mirror the hard corner in RTL so the bubble tail stays on the side the
+    // bubble is aligned to (Compose flips Alignment.Start/End for RTL).
+    val hardCornerOnLeft = if (isRtl) !hardCornerAtLeftOrRight else hardCornerAtLeftOrRight
     val path =
       Path().apply {
         addRoundRect(
@@ -52,11 +56,11 @@ class MessageBubbleShape(
             right = size.width,
             bottom = size.height,
             topLeftCornerRadius =
-              if (hardCornerAtLeftOrRight) CornerRadius(0f, 0f)
+              if (hardCornerOnLeft) CornerRadius(0f, 0f)
               else CornerRadius(radiusPx, radiusPx),
             topRightCornerRadius =
-              if (hardCornerAtLeftOrRight) CornerRadius(radiusPx, radiusPx)
-              else CornerRadius(0f, 0f), // No rounding here
+              if (hardCornerOnLeft) CornerRadius(radiusPx, radiusPx)
+              else CornerRadius(0f, 0f),
             bottomLeftCornerRadius = CornerRadius(radiusPx, radiusPx),
             bottomRightCornerRadius = CornerRadius(radiusPx, radiusPx),
           )


### PR DESCRIPTION
Fixes #367

In RTL, `Alignment.Start/End` auto-flips so user bubbles end up on the left and agent bubbles on the right — but `MessageBubbleShape` ignored `layoutDirection` and kept the hard corner on the original side. So the tail pointed away from the sender.

Mirror the hard corner when `layoutDirection == LayoutDirection.Rtl`. One file, ~4 lines.

Reproduced by switching system language to Hebrew (per the comment on the issue).