### PR TITLE
feat: restore Gemini Search skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .DS_Store
+.opencode/
+.python-version
+.mise.toml

--- a/.nojekyll
+++ b/.nojekyll
@@ -1,0 +1,1 @@
+nojekyll

--- a/skills/featured/gemini-search/IOS_DISTRIBUTION.md
+++ b/skills/featured/gemini-search/IOS_DISTRIBUTION.md
@@ -1,0 +1,34 @@
+# Gemini Search iOS distribution path
+
+Approved path: host the existing `skills/featured/gemini-search/` folder on GitHub Pages and load it in iOS Gallery with `Load skill from URL`.
+
+Why this path:
+
+- iOS Gallery can load shared JS skills from a hosted skill-folder URL.
+- This repo does not contain the closed-source iOS app code or a live featured-skill allowlist hookup, so app-packaging or official featured-list distribution cannot be completed here.
+- GitHub Pages serves the folder with the MIME types the hidden webview needs, while `github.com` and `raw.githubusercontent.com` do not.
+
+Hosted folder URL:
+
+- `https://johanesalxd.github.io/gallery/skills/featured/gemini-search`
+
+Browser verification URL:
+
+- `https://johanesalxd.github.io/gallery/skills/featured/gemini-search/SKILL.md`
+
+Notes:
+
+- `.nojekyll` already exists at the repo root so GitHub Pages can serve raw `SKILL.md` instead of rewriting it.
+- Keep using the built-in `require-secret` flow for the Gemini API key; do not embed the key in the skill files or URL.
+
+Jo iOS test steps:
+
+1. Ensure GitHub Pages is enabled for the `main` branch / root of `johanesalxd/gallery`.
+2. Open Google AI Edge Gallery on iPhone.
+3. Enter Agent Skills, tap `+`, then choose `Load skill from URL`.
+4. Paste `https://johanesalxd.github.io/gallery/skills/featured/gemini-search`.
+5. Enable the imported skill, run a factual query, and provide the Gemini API key when prompted.
+
+Fallback only if URL import still regresses on iOS:
+
+- Import the same `gemini-search` folder from local storage instead of changing the skill implementation.

--- a/skills/featured/gemini-search/SKILL.md
+++ b/skills/featured/gemini-search/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: gemini-search
+description: Search the web using Google Search via Gemini grounding API and return a synthesized answer with sources.
+metadata:
+  require-secret: true
+  require-secret-description: Enter your Gemini API key from https://aistudio.google.com/app/apikey
+  homepage: https://github.com/google-ai-edge/gallery
+---
+
+# Gemini Search
+
+This skill searches the live web using Google Search grounding via the Gemini API and returns a direct answer with sources.
+
+## Instructions
+
+You MUST call the `run_js` tool using `index.html`.
+
+### Exact payload schema
+Pass `data` as a JSON string with exactly one field:
+- **query**: String, Required.
+
+### Mandatory query construction rules
+- You MUST preserve the user's original question as literally as possible.
+- You MUST preserve the user's original intent.
+- You MUST NOT convert a factual question into a prediction, opinion, or generic topic.
+- You MUST NOT replace a full question with vague keywords when the original question is already clear.
+- If the user asks about **whether**, **is**, **did**, **has**, **current**, **latest**, **status**, **qualify**, **qualified**, **going to**, or similar status/outcome wording, you MUST keep that wording in the `query` field.
+- If the user already wrote a clear search-style question, copy it with minimal changes.
+- If unsure, prefer the user's longer literal question over a shorter rewritten query.
+
+### Do NOT do this
+- Do NOT rewrite `Will Italy go to the next World Cup?` into `Italy World Cup prediction`
+- Do NOT rewrite `Did Company X raise funding?` into `Company X funding`
+- Do NOT rewrite `Is Product Y available in Singapore?` into `Product Y Singapore`
+
+### Good examples
+- User: `Can you search whether Italy will go to next world cup or not`
+  - `query`: `Can you search whether Italy will go to next world cup or not`
+- User: `Did OpenAI just raise a new funding round?`
+  - `query`: `Did OpenAI just raise a new funding round?`
+- User: `Is the Nintendo Switch 2 available in Singapore yet?`
+  - `query`: `Is the Nintendo Switch 2 available in Singapore yet?`
+- User: `What's the latest on OpenAI's funding round?`
+  - `query`: `What's the latest on OpenAI's funding round?`
+
+### After the tool returns
+- Answer the user's question directly.
+- Keep the answer concise and factual.
+- Cite sources inline or in a short sources list.
+- If an error is returned, report it clearly and suggest checking the Gemini API key and permissions.
+
+DO NOT use any other tool. DO NOT call `run_intent`.

--- a/skills/featured/gemini-search/SKILL.md
+++ b/skills/featured/gemini-search/SKILL.md
@@ -4,7 +4,7 @@ description: Search the web using Google Search via Gemini grounding API and ret
 metadata:
   require-secret: true
   require-secret-description: Enter your Gemini API key from https://aistudio.google.com/app/apikey
-  homepage: https://github.com/google-ai-edge/gallery
+  homepage: https://johanesalxd.github.io/gallery/skills/featured/gemini-search
 ---
 
 # Gemini Search

--- a/skills/featured/gemini-search/scripts/index.html
+++ b/skills/featured/gemini-search/scripts/index.html
@@ -1,0 +1,118 @@
+<!--
+@license
+Copyright 2026 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================
+-->
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Gemini Search</title>
+  </head>
+  <body>
+    <script>
+      window['ai_edge_gallery_get_result'] = async (dataStr, secret) => {
+        try {
+          const jsonData = JSON.parse(dataStr || '{}');
+          const query = jsonData.query;
+          if (!query) {
+            return JSON.stringify({ error: 'No query provided.' });
+          }
+
+          const apiKey = secret;
+          if (!apiKey) {
+            return JSON.stringify({ error: 'No Gemini API key provided. Please enter your API key.' });
+          }
+
+          const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash-preview:generateContent?key=${apiKey}`;
+
+          const groundedPrompt = [
+            'Answer the user\'s question directly using current Google Search grounding.',
+            'Treat the text below as the exact user question.',
+            'Do not reinterpret a factual question as a prediction question.',
+            'If the question is about a current status, lead with the current status in the first sentence.',
+            'Then give a brief explanation and include source links when available.',
+            '',
+            'User question:',
+            query,
+          ].join('\n');
+
+          const requestBody = {
+            contents: [{ parts: [{ text: groundedPrompt }], role: 'user' }],
+            tools: [{ googleSearch: {} }],
+            generationConfig: { temperature: 0.2, maxOutputTokens: 1024 },
+          };
+
+          const response = await fetch(url, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(requestBody),
+          });
+
+          if (!response.ok) {
+            const errorText = await response.text();
+            let errorMessage = `HTTP error ${response.status}`;
+            try {
+              const errorJson = JSON.parse(errorText);
+              if (errorJson.error && errorJson.error.message) {
+                errorMessage = errorJson.error.message;
+              }
+            } catch (_) {
+              // Use the default error message if JSON parse fails
+            }
+            return JSON.stringify({ error: errorMessage });
+          }
+
+          const data = await response.json();
+
+          if (!data.candidates || data.candidates.length === 0) {
+            return JSON.stringify({ error: 'No response from Gemini API.' });
+          }
+
+          const candidate = data.candidates[0];
+          const answerText = candidate.content.parts[0].text || '';
+
+          // Extract grounding sources if present
+          const groundingChunks =
+            candidate.groundingMetadata && candidate.groundingMetadata.groundingChunks
+              ? candidate.groundingMetadata.groundingChunks
+              : [];
+
+          let result = answerText;
+
+          if (groundingChunks.length > 0) {
+            const seen = new Set();
+            const sources = groundingChunks
+              .filter((chunk) => chunk.web && chunk.web.uri)
+              .filter((chunk) => {
+                if (seen.has(chunk.web.uri)) return false;
+                seen.add(chunk.web.uri);
+                return true;
+              })
+              .map((chunk) => `- [${chunk.web.title || chunk.web.uri}](${chunk.web.uri})`)
+              .join('\n');
+
+            if (sources) {
+              result += `\n\nSources:\n${sources}`;
+            }
+          }
+
+          return JSON.stringify({ result });
+        } catch (e) {
+          console.error(e);
+          return JSON.stringify({ error: `Failed to search: ${e.message}` });
+        }
+      };
+    </script>
+  </body>
+</html>

--- a/skills/featured/gemini-search/scripts/index.html
+++ b/skills/featured/gemini-search/scripts/index.html
@@ -34,23 +34,22 @@ limitations under the License.
             return JSON.stringify({ error: 'No Gemini API key provided. Please enter your API key.' });
           }
 
-          const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash-preview:generateContent?key=${apiKey}`;
+          const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:generateContent?key=${encodeURIComponent(apiKey)}`;
 
           const groundedPrompt = [
-            'Answer the user\'s question directly using current Google Search grounding.',
-            'Treat the text below as the exact user question.',
-            'Do not reinterpret a factual question as a prediction question.',
-            'If the question is about a current status, lead with the current status in the first sentence.',
-            'Then give a brief explanation and include source links when available.',
+            'Answer the exact user question directly using current Google Search grounding.',
+            'Preserve the user\'s wording and intent exactly; do not reinterpret the question.',
+            'Lead with the current answer in the first sentence when the question is about current status.',
+            'Then give a short explanation based on grounded search results.',
             '',
-            'User question:',
+            'Exact user question:',
             query,
           ].join('\n');
 
           const requestBody = {
-            contents: [{ parts: [{ text: groundedPrompt }], role: 'user' }],
+            contents: [{ role: 'user', parts: [{ text: groundedPrompt }] }],
             tools: [{ googleSearch: {} }],
-            generationConfig: { temperature: 0.2, maxOutputTokens: 1024 },
+            generationConfig: { temperature: 0.2, maxOutputTokens: 768 },
           };
 
           const response = await fetch(url, {
@@ -80,34 +79,38 @@ limitations under the License.
           }
 
           const candidate = data.candidates[0];
-          const answerText = candidate.content.parts[0].text || '';
+          const answerText =
+            (candidate.content && Array.isArray(candidate.content.parts)
+              ? candidate.content.parts.map((part) => part.text || '').join('')
+              : '') || '';
 
-          // Extract grounding sources if present
           const groundingChunks =
-            candidate.groundingMetadata && candidate.groundingMetadata.groundingChunks
+            candidate.groundingMetadata && Array.isArray(candidate.groundingMetadata.groundingChunks)
               ? candidate.groundingMetadata.groundingChunks
               : [];
 
-          let result = answerText;
+          const seen = new Set();
+          const sources = groundingChunks
+            .filter((chunk) => chunk.web && chunk.web.uri)
+            .map((chunk) => ({
+              title: chunk.web.title || chunk.web.uri,
+              url: chunk.web.uri,
+            }))
+            .filter((source) => {
+              if (seen.has(source.url)) return false;
+              seen.add(source.url);
+              return true;
+            });
 
-          if (groundingChunks.length > 0) {
-            const seen = new Set();
-            const sources = groundingChunks
-              .filter((chunk) => chunk.web && chunk.web.uri)
-              .filter((chunk) => {
-                if (seen.has(chunk.web.uri)) return false;
-                seen.add(chunk.web.uri);
-                return true;
-              })
-              .map((chunk) => `- [${chunk.web.title || chunk.web.uri}](${chunk.web.uri})`)
-              .join('\n');
+          const result = answerText.trim();
+          const renderedSources = sources.map((source) => `- ${source.title}: ${source.url}`).join('\n');
+          const presentable = renderedSources ? `${result}\n\nSources:\n${renderedSources}` : result;
 
-            if (sources) {
-              result += `\n\nSources:\n${sources}`;
-            }
-          }
-
-          return JSON.stringify({ result });
+          return JSON.stringify({
+            result,
+            presentable,
+            sources,
+          });
         } catch (e) {
           console.error(e);
           return JSON.stringify({ error: `Failed to search: ${e.message}` });

--- a/skills/featured/gemini-search/scripts/index.test.mjs
+++ b/skills/featured/gemini-search/scripts/index.test.mjs
@@ -1,0 +1,179 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import vm from 'node:vm';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const htmlPath = path.join(__dirname, 'index.html');
+
+async function loadSkill(fetchImpl) {
+  const html = await fs.readFile(htmlPath, 'utf8');
+  const scriptMatch = html.match(/<script>([\s\S]*?)<\/script>/i);
+  assert.ok(scriptMatch, 'expected inline <script> in index.html');
+
+  const context = {
+    window: {},
+    fetch: fetchImpl,
+    console: { error: () => {} },
+    JSON,
+    Set,
+    encodeURIComponent,
+  };
+  context.globalThis = context;
+
+  vm.runInNewContext(scriptMatch[1], context, { filename: htmlPath });
+  assert.equal(typeof context.window.ai_edge_gallery_get_result, 'function');
+  return context.window.ai_edge_gallery_get_result;
+}
+
+async function invoke({ data, secret = 'test-secret', fetchImpl }) {
+  const runSkill = await loadSkill(fetchImpl);
+  const raw = await runSkill(data, secret);
+  return JSON.parse(raw);
+}
+
+test('returns clear error when query is missing', async () => {
+  const result = await invoke({
+    data: JSON.stringify({}),
+    fetchImpl: async () => {
+      throw new Error('fetch should not be called');
+    },
+  });
+
+  assert.deepEqual(result, { error: 'No query provided.' });
+});
+
+test('returns clear error when secret is missing', async () => {
+  const result = await invoke({
+    data: JSON.stringify({ query: 'latest Gemini news' }),
+    secret: '',
+    fetchImpl: async () => {
+      throw new Error('fetch should not be called');
+    },
+  });
+
+  assert.deepEqual(result, {
+    error: 'No Gemini API key provided. Please enter your API key.',
+  });
+});
+
+test('calls gemini-3.5-flash with Google Search grounding and preserves the literal query', async () => {
+  const query = 'Can you search whether Italy will go to next World Cup or not?';
+  const calls = [];
+
+  const result = await invoke({
+    data: JSON.stringify({ query }),
+    secret: 'secret value',
+    fetchImpl: async (url, options) => {
+      calls.push({ url, options });
+      return {
+        ok: true,
+        async json() {
+          return {
+            candidates: [
+              {
+                content: { parts: [{ text: 'Italy has not yet qualified.' }] },
+                groundingMetadata: { groundingChunks: [] },
+              },
+            ],
+          };
+        },
+      };
+    },
+  });
+
+  assert.equal(result.result, 'Italy has not yet qualified.');
+  assert.equal(calls.length, 1);
+  assert.match(
+    calls[0].url,
+    /^https:\/\/generativelanguage\.googleapis\.com\/v1beta\/models\/gemini-3\.5-flash:generateContent\?key=secret%20value$/
+  );
+
+  const body = JSON.parse(calls[0].options.body);
+  assert.deepEqual(body.tools, [{ googleSearch: {} }]);
+  assert.equal(body.contents[0].role, 'user');
+  assert.equal(body.contents[0].parts[0].text.includes(query), true);
+  assert.equal(body.contents[0].parts[0].text.includes('Exact user question:'), true);
+});
+
+test('dedupes sources by URL and builds presentable output', async () => {
+  const result = await invoke({
+    data: JSON.stringify({ query: 'latest launch update' }),
+    fetchImpl: async () => ({
+      ok: true,
+      async json() {
+        return {
+          candidates: [
+            {
+              content: { parts: [{ text: 'Launch remains on schedule.\n' }] },
+              groundingMetadata: {
+                groundingChunks: [
+                  { web: { title: 'Source A', uri: 'https://example.com/a' } },
+                  { web: { title: 'Source A duplicate', uri: 'https://example.com/a' } },
+                  { web: { title: '', uri: 'https://example.com/b' } },
+                  { ignored: true },
+                ],
+              },
+            },
+          ],
+        };
+      },
+    }),
+  });
+
+  assert.deepEqual(result.sources, [
+    { title: 'Source A', url: 'https://example.com/a' },
+    { title: 'https://example.com/b', url: 'https://example.com/b' },
+  ]);
+  assert.equal(
+    result.presentable,
+    'Launch remains on schedule.\n\nSources:\n- Source A: https://example.com/a\n- https://example.com/b: https://example.com/b'
+  );
+});
+
+test('returns API JSON error message on non-OK HTTP response', async () => {
+  const result = await invoke({
+    data: JSON.stringify({ query: 'latest rate decision' }),
+    fetchImpl: async () => ({
+      ok: false,
+      status: 403,
+      async text() {
+        return JSON.stringify({ error: { message: 'API key invalid' } });
+      },
+    }),
+  });
+
+  assert.deepEqual(result, { error: 'API key invalid' });
+});
+
+test('falls back to HTTP status message when error body is not JSON', async () => {
+  const result = await invoke({
+    data: JSON.stringify({ query: 'latest rate decision' }),
+    fetchImpl: async () => ({
+      ok: false,
+      status: 502,
+      async text() {
+        return 'bad gateway';
+      },
+    }),
+  });
+
+  assert.deepEqual(result, { error: 'HTTP error 502' });
+});
+
+test('returns a clear error when Gemini responds without candidates', async () => {
+  const result = await invoke({
+    data: JSON.stringify({ query: 'latest rate decision' }),
+    fetchImpl: async () => ({
+      ok: true,
+      async json() {
+        return { candidates: [] };
+      },
+    }),
+  });
+
+  assert.deepEqual(result, { error: 'No response from Gemini API.' });
+});


### PR DESCRIPTION
## Summary
- Restores a `gemini-search` Agent Skill under `skills/featured/` for Google AI Edge Gallery.
- Updates the skill to use direct Gemini `gemini-3.5-flash` `generateContent` with Google Search grounding.
- Adds a mocked Node test harness for the inline JS skill runtime and documents the iOS/GitHub Pages loading path.

## Target use case
- iOS Google AI Edge Gallery.
- Local Gemma 4 small as the on-device tool-calling model.
- Hosted shared skill folder loaded via Agent Skills → Load skill from URL.

## Validation
- `node --test skills/featured/gemini-search/scripts/index.test.mjs` — 7/7 passed.
- Changed Markdown fence scan passed.
- Changed-file sensitive-string scan passed.
- Working tree was clean before push.

## Notes
- The skill keeps API key handling in Gallery's `require-secret` flow; no key is embedded.
- `IOS_DISTRIBUTION.md` documents the GitHub Pages URL path and fallback local import path.