### PR TITLE
Enable MediaTek NPU runtime via uses-native-library manifest entries

### DIFF
--- a/Android/src/app/src/main/AndroidManifest.xml
+++ b/Android/src/app/src/main/AndroidManifest.xml
@@ -160,6 +160,45 @@
         <uses-native-library android:name="libOpenCL.so" android:required="false"/>
         <uses-native-library android:name="libcdsprpc.so" android:required="false" />
         <uses-native-library android:name="libedgetpu_litert.so" android:required="false" />
+
+        <!-- MediaTek NPU runtime: vendor libs published per MediaTek's
+             /system/etc/public.libraries-mtk.txt. Required so the LiteRT
+             MTK dispatcher (libLiteRtDispatch_MediaTek.so, bundled in
+             split_mediatek_runtime_v8) can dlopen its transitive vendor
+             dependencies at construction time. Without these declarations,
+             Android's nativeloader denies the dlopen and the adapter
+             crashes with a SIGSEGV in its static constructor on devices
+             like Vivo PD2417 (D9300). All marked required="false" so the
+             app installs cleanly on non-MTK SoCs. -->
+        <uses-native-library android:name="libapuwareapusys.mtk.so" android:required="false" />
+        <uses-native-library android:name="libapuwareapusys_v2.mtk.so" android:required="false" />
+        <uses-native-library android:name="libapuwarexrp.mtk.so" android:required="false" />
+        <uses-native-library android:name="libapuwarexrp_v2.mtk.so" android:required="false" />
+        <uses-native-library android:name="libapuwareutils.mtk.so" android:required="false" />
+        <uses-native-library android:name="libapuwareutils_v2.mtk.so" android:required="false" />
+        <uses-native-library android:name="libapuwarehmp.mtk.so" android:required="false" />
+        <uses-native-library android:name="libneuron_graph_delegate.mtk.so" android:required="false" />
+        <uses-native-library android:name="libneuronusdk_adapter.mtk.so" android:required="false" />
+        <uses-native-library android:name="libneuronusdk_adapter.9.mtk.so" android:required="false" />
+        <uses-native-library android:name="libneuronservice_adapter.mtk.so" android:required="false" />
+        <uses-native-library android:name="libneuron_sys_util.mtk.so" android:required="false" />
+        <uses-native-library android:name="libtflite_mtk.mtk.so" android:required="false" />
+        <uses-native-library android:name="libarmnn_ndk.mtk.so" android:required="false" />
+        <uses-native-library android:name="libcmdl_ndk.mtk.so" android:required="false" />
+        <uses-native-library android:name="libnir_neon_driver_ndk.mtk.so" android:required="false" />
+        <uses-native-library android:name="libmvpu_runtime.mtk.so" android:required="false" />
+        <uses-native-library android:name="libmvpu_runtime_pub.mtk.so" android:required="false" />
+        <uses-native-library android:name="libmvpu_engine_pub.mtk.so" android:required="false" />
+        <uses-native-library android:name="libmvpu_pattern_pub.mtk.so" android:required="false" />
+        <uses-native-library android:name="libmvpuop_mtk_cv.mtk.so" android:required="false" />
+        <uses-native-library android:name="libmvpuop_mtk_nn.mtk.so" android:required="false" />
+        <uses-native-library android:name="libmvpu_runtime_25.mtk.so" android:required="false" />
+        <uses-native-library android:name="libmvpu_runtime_25_pub.mtk.so" android:required="false" />
+        <uses-native-library android:name="libmvpu_engine_25_pub.mtk.so" android:required="false" />
+        <uses-native-library android:name="libmvpu_pattern_25_pub.mtk.so" android:required="false" />
+        <uses-native-library android:name="libmvpuop25_mtk_cv.mtk.so" android:required="false" />
+        <uses-native-library android:name="libmvpuop25_mtk_nn.mtk.so" android:required="false" />
+        <uses-native-library android:name="libmvpu_config.mtk.so" android:required="false" />
     </application>
 
 </manifest>


### PR DESCRIPTION
## Summary

Add 29 `<uses-native-library>` entries to `Android/src/app/src/main/AndroidManifest.xml` so that the MediaTek NPU adapter — `libneuronusdk_adapter.mtk.so` (shipped in the existing `split_mediatek_runtime_v8` split APK) — can `dlopen` its transitive vendor library dependencies on devices with a MediaTek SoC. Mirrors the existing entries for Qualcomm (`libcdsprpc.so`) and Google Tensor (`libedgetpu_litert.so`). All marked `android:required=\"false\"` so non-MediaTek devices install and run as before.

## Why

`libneuronusdk_adapter.mtk.so`'s static constructor `dlopen`s ~29 sibling MediaTek vendor libs (`libmvpu_runtime_25_pub.mtk.so`, `libapuwarexrp_v2.mtk.so`, `libneuron_sys_util.mtk.so`, …) from `/vendor/lib64/`. MediaTek publishes the full list in `/system/etc/public.libraries-mtk.txt` on supported devices, but Android's `nativeloader` only routes those into an app's linker namespace if the app declares them via `<uses-native-library>`.

Without these entries, on every device I've tested with the official `Gemma3-1B-IT_q4_ekv1280_mt6989.litertlm` bundle the app crashes on first NPU invoke:

```
F libc:  Fatal signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x0
         in tid 30440 (DefaultDispatch), pid 30400 (ai.edge.gallery)
F DEBUG: Process uptime: 35s
         #00 pc 0x0  <unknown>
         #01-03 libneuronusdk_adapter.mtk.so (BuildId bfa87e71…)  ← constructor
         #04 linker64 __dl__ZN6soinfo17call_constructorsEv+532
         #07 libdl.so dlopen+16
         #08-11 libLiteRtDispatch_MediaTek.so
```

The crash signature is reproducible — the null PC is the function pointer the constructor would have populated from a sibling lib that the linker refused to load.

## Verification

After applying the patch on Vivo PD2417 (iQOO Z9 Turbo+, MediaTek Dimensity 9300, firmware `PD2417_A_16.2.9.2.W10.V000L1`, Android 16 / SDK 36) and re-signing/re-installing the split APK set, `logcat` shows the namespace extension working:

```
D nativeloader: Extending system_exposed_libraries: libapuwareapusys.mtk.so:
  libapuwareapusys_v2.mtk.so:libapuwarexrp.mtk.so:...:libmvpu_config.mtk.so
```

End-to-end smoke test (`Gemma3-1B-IT_q4_ekv1280_mt6989.litertlm`):

- `LiteRtCreateCompiledModel(NPU)` → `rc=0`
- `LiteRtCompiledModelIsFullyAccelerated` → `is_full=1`
- `LiteRtRunCompiledModel` → `rc=0`
- App generates text. Prompt: *\"What is the capital of Taiwan?\"* → *\"The capital of Taiwan was Taipei.\"* (Sampling quirk aside, the NPU executed prefill+decode in the app, no crash.)

## How the library list was derived

Union of:

1. Names extracted from `strings libneuronusdk_adapter.mtk.so` that match `^lib.*\\.so$` and are reachable from the constructor's dlopen chain.
2. Names actually present in `/system/etc/public.libraries-mtk.txt` on a retail D9300 device.

Libraries that exist in the adapter's lookup table but aren't in any public list (e.g. `libmdla_standalone.so`, `libedma_custom.so`) are deliberately *not* declared — they appear to be optional probe paths the adapter tolerates failing.

## Test plan

- [x] App installs on MediaTek device (Vivo PD2417 / D9300).
- [x] App installs on non-MediaTek device (unchanged behavior — `required=\"false\"`).
- [x] `Gemma3-1B-IT_q4_ekv1280_mt6989.litertlm` loads without `SIGSEGV`.
- [x] `IsFullyAccelerated` returns true.
- [x] Inference completes, text output rendered.
- [ ] Test on additional MediaTek-firmware OEMs (Xiaomi, OPPO, OnePlus) — community welcome.

## Scope

Manifest-only change. No code, no resources, no behavior change on non-MediaTek devices.