### PR TITLE
Zizmor fixes - security findings in GitHub Actions workflows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,0 @@
-# Security and infrastructure team approval required for workflows
-/.github/workflows/ @security-team @infrastructure-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Security and infrastructure team approval required for workflows
+/.github/workflows/ @security-team @infrastructure-team

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/build_android.yaml
+++ b/.github/workflows/build_android.yaml
@@ -22,10 +22,10 @@
           working-directory: ./Android/src
       steps:
         - name: Checkout the source code
-          uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3
+          uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
           with:
             persist-credentials: false
-        - uses: actions/setup-java@d7793b545071e98d581d3bf084a51c3213318a07 # v4
+        - uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4
           with:
             distribution: 'temurin'
             java-version: '21'

--- a/.github/workflows/build_android.yaml
+++ b/.github/workflows/build_android.yaml
@@ -15,13 +15,17 @@
     build_apk:
       name: Build Android APK
       runs-on: ubuntu-latest
+      permissions:
+        contents: read
       defaults:
         run:
           working-directory: ./Android/src
       steps:
         - name: Checkout the source code
-          uses: actions/checkout@v3
-        - uses: actions/setup-java@v4
+          uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3
+          with:
+            persist-credentials: false
+        - uses: actions/setup-java@d7793b545071e98d581d3bf084a51c3213318a07 # v4
           with:
             distribution: 'temurin'
             java-version: '21'

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -32,7 +32,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
       # Create the nested directory structure
       - name: Prepare for nested deployment
         run: |
@@ -40,12 +42,12 @@ jobs:
           # Move all files (except the staging folder itself) into the subdirectory
           rsync -rr --exclude='staging' ./skills/ staging/skills/
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           # Upload entire repository
           path: 'staging/'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,27 @@
+name: GitHub Actions Security Audit with zizmor
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["*"]
+
+jobs:
+  zizmor:
+    name: zizmor latest via uv
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+      
+      - name: Install uv
+        uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081 # v5
+
+      - name: Run zizmor 🌈
+        run: uvx zizmor .
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -19,7 +19,7 @@ jobs:
           persist-credentials: false
       
       - name: Install uv
-        uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081 # v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
 
       - name: Run zizmor 🌈
         run: uvx zizmor .

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,3 +2,12 @@ The repository is not currently ready for code contributions. We will
 make a separate announcement when we are ready for OSS users to make
 contributions to it.
 
+## Security Requirements
+
+To maintain a secure development environment, all GitHub Actions workflows and configuration changes are subject to security scanning using [Zizmor](https://github.com/woodruffw/zizmor).
+
+When contributing to workflows, please ensure:
+- All external GitHub Actions are pinned to a specific full-length commit SHA.
+- `persist-credentials: false` is set for `actions/checkout` unless strictly required.
+- Explicit permissions are defined for all jobs (avoid overly broad permissions).
+- All workflows pass Zizmor security checks.


### PR DESCRIPTION
This PR introduces automated security scanning for our GitHub Actions workflows using [Zizmor](https://github.com/woodruffw/zizmor) and addresses the findings to ensure our CI/CD pipelines follow security best practices.

* **Added Zizmor Security Scanner:** Implemented a new workflow (`zizmor.yml`) to automatically audit all GitHub Actions workflows for security vulnerabilities (like unpinned dependencies, dangerous permissions, etc.) on pushes and pull requests.
* **Updated Action SHAs:** Pinned all GitHub Actions in `build_android.yaml` and `zizmor.yml` to their latest peeled commit SHAs rather than lightweight/annotated tags or outdated versions. This satisfies Zizmor's strict requirement for full commit SHA pinning to prevent supply chain attacks.
  * Upgraded `actions/checkout` to `v4` in the Android build workflow.
  * Upgraded `actions/setup-java` to the latest `v4` SHA.
  * Fixed the `astral-sh/setup-uv` SHA to point to the actual commit SHA rather than the annotated tag object.