### PR TITLE
Fix download failure notification using incorrect string resource

### DIFF
--- a/Android/src/app/src/main/java/com/google/ai/edge/gallery/data/DownloadRepository.kt
+++ b/Android/src/app/src/main/java/com/google/ai/edge/gallery/data/DownloadRepository.kt
@@ -245,7 +245,7 @@ class DefaultDownloadRepository(
             } else {
               sendNotification(
                 title = context.getString(R.string.notification_title_fail),
-                text = context.getString(R.string.notification_content_success).format(model.name),
+                text = context.getString(R.string.notification_content_fail).format(model.name),
                 taskId = "",
                 modelName = "",
               )


### PR DESCRIPTION
When a model download fails, DownloadRepository was referencing R.string.notification_content_success instead of
R.string.notification_content_fail, causing the notification to display "Model Download Failed" with a success message body.